### PR TITLE
Check end of transmission after popping data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ void process_scrutiny_loop()
     if (c != -1)
     {
         uint8_t uc = static_cast<uint8_t>(c);
-        scrutiny_handler.comm()->receive_data(&uc, 1);  // Data from Serial port pushed into scrutiny-embedded lib
+        scrutiny_handler.receive_data(&uc, 1);  // Data from Serial port pushed into scrutiny-embedded lib
     }
+    
+    scrutiny_handler.process(timestep_us * 10); // Timesteps are counted in multiple of 100ns
     
     // Sends data
     uint8_t buffer[16];
-    if (scrutiny_handler.comm()->data_to_send() > 0)
+    if (scrutiny_handler.data_to_send() > 0)
     {
-        uint16_t nread = scrutiny_handler.comm()->pop_data(buffer, sizeof(buffer));  // Reads data from scrutiny lib
+        uint16_t nread = scrutiny_handler.pop_data(buffer, sizeof(buffer));  // Reads data from scrutiny lib
         Serial.write(buffer, nread);                         // Sends data to the serial port
     }
 
-    scrutiny_handler.process(timestep_us * 10); // Timesteps are counted in multiple of 100ns
 
     last_call_us = current_us;  
 }

--- a/lib/inc/protocol/scrutiny_comm_handler.hpp
+++ b/lib/inc/protocol/scrutiny_comm_handler.hpp
@@ -39,7 +39,7 @@ namespace scrutiny
             /// @brief Move data from the outside world (received by the server) to the scrutiny lib
             /// @param data Buffer containing the received data
             /// @param len Number of bytes to read
-            void receive_data(uint8_t *data, uint16_t len);
+            void receive_data(uint8_t const *data, uint16_t len);
 
             /// @brief Send a response to the server
             /// @param response The response object

--- a/lib/inc/scrutiny_main_handler.hpp
+++ b/lib/inc/scrutiny_main_handler.hpp
@@ -53,6 +53,23 @@ namespace scrutiny
         /// @param timestep_100ns The time elapsed since last call to this function, in multiple of 100ns.
         void process(const timediff_t timestep_100ns);
 
+        inline void receive_data(uint8_t const *data, uint16_t const len)
+        {
+            m_comm_handler.receive_data(data, len);
+        }
+
+        inline uint16_t pop_data(uint8_t *buffer, uint16_t len)
+        {
+            uint16_t const size = m_comm_handler.pop_data(buffer, len);
+            check_finished_sending();
+            return size;
+        }
+
+        inline uint16_t data_to_send(void) const
+        {
+            return m_comm_handler.data_to_send();
+        }
+
 #if SCRUTINY_ENABLE_DATALOGGING
         /// @brief Returns the state of the datalogger. Thread safe
         inline datalogging::DataLogger::State get_datalogger_state(void) const
@@ -122,6 +139,7 @@ namespace scrutiny
 
     private:
         void process_loops(void);
+        void check_finished_sending(void);
         void process_request(const protocol::Request *const request, protocol::Response *const response);
         protocol::ResponseCode process_get_info(const protocol::Request *const request, protocol::Response *const response);
         protocol::ResponseCode process_comm_control(const protocol::Request *const request, protocol::Response *const response);

--- a/lib/inc/scrutiny_types.hpp
+++ b/lib/inc/scrutiny_types.hpp
@@ -142,7 +142,6 @@ namespace scrutiny
     /// @brief  Represent a RuntimePublishedValue definition. It is a data object with a type and a ID that can be read/written by the server
     struct RuntimePublishedValue
     {
-    public:
         uint16_t id;
         VariableType type;
     };

--- a/lib/src/protocol/scrutiny_comm_handler.cpp
+++ b/lib/src/protocol/scrutiny_comm_handler.cpp
@@ -47,7 +47,7 @@ namespace scrutiny
             reset();
         }
 
-        void CommHandler::receive_data(uint8_t *data, uint16_t len)
+        void CommHandler::receive_data(uint8_t const *data, uint16_t len)
         {
             uint16_t i = 0;
 
@@ -376,6 +376,7 @@ namespace scrutiny
             if (m_nbytes_sent >= m_nbytes_to_send)
             {
                 reset_tx();
+                wait_next_request();
             }
 
             return i;

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -7,7 +7,6 @@
 //   Copyright (c) 2021-2023 Scrutiny Debugger
 
 #include <string.h>
-
 #include "scrutiny_setup.hpp"
 #include "scrutiny_main_handler.hpp"
 #include "scrutiny_software_id.hpp"
@@ -442,6 +441,17 @@ namespace scrutiny
             }
         }
 
+        check_finished_sending();
+
+        // Some commands affect loops and datalogging, so we reprocess right away
+        process_loops();
+#if SCRUTINY_ENABLE_DATALOGGING
+        process_datalogging_logic();
+#endif
+    }
+
+    void MainHandler::check_finished_sending()
+    {
         if (m_processing_request)
         {
             if (!m_comm_handler.transmitting()) // Will be false if NoResponseToSend or if finished transmitting
@@ -457,11 +467,6 @@ namespace scrutiny
                 }
             }
         }
-
-        process_loops();
-#if SCRUTINY_ENABLE_DATALOGGING
-        process_datalogging_logic();
-#endif
     }
 
     bool MainHandler::rpv_exists(const uint16_t id) const

--- a/projects/platformio/src/main.cpp
+++ b/projects/platformio/src/main.cpp
@@ -47,19 +47,19 @@ void loop()
     if (c != -1)
     {
         uint8_t uc = static_cast<uint8_t>(c);
-        scrutiny_handler.comm()->receive_data(&uc, 1);
-    }
-
-    uint8_t buffer[16];
-    uint32_t data_to_send = scrutiny_handler.comm()->data_to_send();
-    data_to_send = min(data_to_send, static_cast<uint32_t>(sizeof(buffer)));
-    if (data_to_send > 0)
-    {
-        scrutiny_handler.comm()->pop_data(buffer, data_to_send);
-        Serial.write(buffer, data_to_send);
+        scrutiny_handler.receive_data(&uc, 1);
     }
 
     scrutiny_handler.process(timestep_us * 10);
+
+    uint8_t buffer[16];
+    uint32_t data_to_send = scrutiny_handler.data_to_send();
+    data_to_send = min(data_to_send, static_cast<uint32_t>(sizeof(buffer)));
+    if (data_to_send > 0)
+    {
+        scrutiny_handler.pop_data(buffer, data_to_send);
+        Serial.write(buffer, data_to_send);
+    }
 
     last_call_us = current_us;
 }

--- a/projects/testapp/src/main.cpp
+++ b/projects/testapp/src/main.cpp
@@ -417,14 +417,15 @@ void process_scrutiny_lib(AbstractCommChannel *channel)
                 cout << endl;
             }
 
-            scrutiny_handler.comm()->receive_data(buffer, static_cast<uint16_t>(len_received));
+            scrutiny_handler.receive_data(buffer, static_cast<uint16_t>(len_received));
+            scrutiny_handler.process(timestep_us * 10);
 
-            uint16_t data_to_send = scrutiny_handler.comm()->data_to_send();
+            uint16_t data_to_send = scrutiny_handler.data_to_send();
             data_to_send = min(data_to_send, static_cast<uint16_t>(sizeof(buffer)));
 
             if (data_to_send > 0)
             {
-                scrutiny_handler.comm()->pop_data(buffer, data_to_send);
+                scrutiny_handler.pop_data(buffer, data_to_send);
                 channel->send(buffer, data_to_send);
 
                 cout << "out: (" << dec << data_to_send << ")\t";
@@ -435,7 +436,6 @@ void process_scrutiny_lib(AbstractCommChannel *channel)
                 cout << endl;
             }
 
-            scrutiny_handler.process(timestep_us * 10);
             vf_loop.process(timestep_us * 10);
             ff_loop.process();
 #if SCRUTINY_BUILD_WINDOWS

--- a/test/commands/test_comm_control.cpp
+++ b/test/commands/test_comm_control.cpp
@@ -68,14 +68,14 @@ TEST_F(TestCommControl, TestDiscover)
     add_crc(request_data, sizeof(request_data) - 4);
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -89,10 +89,10 @@ TEST_F(TestCommControl, TestDiscoverWrongMagic)
     request_data[4] = ~request_data[4];
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_EQ(n_to_read, 0u); // No data because we are not connected and discover is invalid. We stay silent
 }
 
@@ -111,13 +111,13 @@ TEST_F(TestCommControl, TestDiscoverWrongMagicWhileConnected)
 
     uint8_t tx_buffer[32];
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     // Now we expect an InvalidRequest response
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, code));
     scrutiny_handler.process(0);
@@ -153,12 +153,12 @@ TEST_F(TestCommControl, TestHeartbeat)
 
         add_crc(request_data, sizeof(request_data) - 4);
         add_crc(expected_response, sizeof(expected_response) - 4);
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(SCRUTINY_COMM_HEARTBEAT_TIMEOUT_US / 2);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_EQ(n_to_read, sizeof(expected_response)) << "challenge=" << static_cast<uint32_t>(challenge);
-        uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
         EXPECT_EQ(nread, n_to_read) << "challenge=" << static_cast<uint32_t>(challenge);
 
         ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response)) << "challenge=" << static_cast<uint32_t>(challenge);
@@ -197,14 +197,14 @@ TEST_F(TestCommControl, TestGetParams)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     scrutiny_handler.comm()->connect();
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -223,15 +223,15 @@ TEST_F(TestCommControl, TestConnect)
     add_crc(request_data, sizeof(request_data) - 4);
 
     ASSERT_FALSE(scrutiny_handler.comm()->is_connected());
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     uint32_t session_id = scrutiny_handler.comm()->get_session_id();
@@ -262,15 +262,15 @@ TEST_F(TestCommControl, TestDisconnect)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     ASSERT_TRUE(scrutiny_handler.comm()->is_connected());
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     scrutiny_handler.process(0); // We need a subsequent call to process because disconnection hapens once the response is completely sent.
 

--- a/test/commands/test_datalog_control.cpp
+++ b/test/commands/test_datalog_control.cpp
@@ -106,14 +106,14 @@ TEST_F(TestDatalogControl, TestUnsupported)
         uint8_t request_data[8] = {5, subfn, 0, 0};
         add_crc(request_data, sizeof(request_data) - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
         ASSERT_GT(n_to_read, 0);
 
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
         ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, failure));
         scrutiny_handler.process(0);
     }
@@ -273,13 +273,13 @@ void TestDatalogControl::test_configure(uint8_t loop_id, uint16_t config_id, dat
     request_data[3] = payload_size & 0xFF;
     add_crc(request_data, 4 + payload_size);
 
-    scrutiny_handler.comm()->receive_data(request_data, payload_size + 8);
+    scrutiny_handler.receive_data(request_data, payload_size + 8);
     scrutiny_handler.process(0);
 
     uint8_t tx_buffer[32]{0};
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
     if (check_response)
     {
@@ -318,14 +318,14 @@ TEST_F(TestDatalogControl, TestGetSetup)
     expected_response[10] = SCRUTINY_DATALOGGING_MAX_SIGNAL;
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
 
@@ -526,14 +526,14 @@ TEST_F(TestDatalogControl, TestArmTriggerNotConfigured)
     uint8_t request_data[8] = {5, 3, 0, 0};
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, protocol::CommandId::DataLogControl, 3, protocol::ResponseCode::FailureToProceed));
     EXPECT_FALSE(scrutiny_handler.datalogger()->armed());
@@ -557,14 +557,14 @@ TEST_F(TestDatalogControl, TestArmDisarmTriggerOK)
     uint8_t arm_expected_response[9] = {0x85, 3, 0, 0, 0};
     add_crc(arm_expected_response, sizeof(arm_expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(arm_request_data, sizeof(arm_request_data));
+    scrutiny_handler.receive_data(arm_request_data, sizeof(arm_request_data));
     scrutiny_handler.process(0);
 
-    n_to_read = scrutiny_handler.comm()->data_to_send();
+    n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
     EXPECT_BUF_EQ(tx_buffer, arm_expected_response, sizeof(arm_expected_response));
     EXPECT_FALSE(scrutiny_handler.datalogger()->armed());
@@ -578,14 +578,14 @@ TEST_F(TestDatalogControl, TestArmDisarmTriggerOK)
     uint8_t diarm_expected_response[9] = {0x85, 4, 0, 0, 0};
     add_crc(diarm_expected_response, sizeof(diarm_expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(disarm_request_data, sizeof(disarm_request_data));
+    scrutiny_handler.receive_data(disarm_request_data, sizeof(disarm_request_data));
     scrutiny_handler.process(0);
 
-    n_to_read = scrutiny_handler.comm()->data_to_send();
+    n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
     EXPECT_BUF_EQ(tx_buffer, diarm_expected_response, sizeof(diarm_expected_response));
     EXPECT_TRUE(scrutiny_handler.datalogger()->armed()); // Still true
@@ -607,12 +607,12 @@ void TestDatalogControl::check_get_status(datalogging::DataLogger::State expecte
     cursor += codecs::encode_32_bits_big_endian(expected_counter, &expected_response[cursor]);
 
     add_crc(expected_response, sizeof(expected_response) - 4);
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
-    n_to_read = scrutiny_handler.comm()->data_to_send();
+    n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
     EXPECT_TRUE( // More verbose than raw data check in case of failure
         IS_PROTOCOL_RESPONSE(
@@ -658,7 +658,7 @@ TEST_F(TestDatalogControl, TestGetStatus)
 
     // Empty transmit buffer
     uint8_t dummy_buffer[32]{0};
-    scrutiny_handler.comm()->pop_data(dummy_buffer, sizeof(dummy_buffer));
+    scrutiny_handler.pop_data(dummy_buffer, sizeof(dummy_buffer));
     EXPECT_TRUE(IS_PROTOCOL_RESPONSE(dummy_buffer, protocol::CommandId::DataLogControl, 2, protocol::ResponseCode::Overflow));
     scrutiny_handler.process(0);
 
@@ -709,12 +709,12 @@ TEST_F(TestDatalogControl, TestGetAcquisitionMetadata)
     uint8_t request_data_before[8] = {5, 6, 0, 0};
     add_crc(request_data_before, sizeof(request_data_before) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data_before, sizeof(request_data_before));
+    scrutiny_handler.receive_data(request_data_before, sizeof(request_data_before));
     scrutiny_handler.process(0);
-    n_to_read = scrutiny_handler.comm()->data_to_send();
+    n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
     // Expect a failure because there is no daa available.
     EXPECT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, protocol::CommandId::DataLogControl, 6, protocol::ResponseCode::FailureToProceed));
@@ -741,12 +741,12 @@ TEST_F(TestDatalogControl, TestGetAcquisitionMetadata)
     uint8_t request_data_after[8] = {5, 6, 0, 0};
     add_crc(request_data_after, sizeof(request_data_after) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data_after, sizeof(request_data_after));
+    scrutiny_handler.receive_data(request_data_after, sizeof(request_data_after));
     scrutiny_handler.process(0);
-    n_to_read = scrutiny_handler.comm()->data_to_send();
+    n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, protocol::CommandId::DataLogControl, 6, protocol::ResponseCode::OK));
     datalogging::DataReader *reader = scrutiny_handler.datalogger()->get_reader();
@@ -773,12 +773,12 @@ TEST_F(TestDatalogControl, TestReadAcquisitionNoDataAvailable)
     uint8_t request_data_before[8] = {5, 7, 0, 0};
     add_crc(request_data_before, sizeof(request_data_before) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data_before, sizeof(request_data_before));
+    scrutiny_handler.receive_data(request_data_before, sizeof(request_data_before));
     scrutiny_handler.process(0);
-    n_to_read = scrutiny_handler.comm()->data_to_send();
+    n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
     // Expect a failure because there is no daa available.
     EXPECT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, protocol::CommandId::DataLogControl, 7, protocol::ResponseCode::FailureToProceed));
@@ -816,12 +816,12 @@ TEST_F(TestDatalogControl, TestReadAcquisitionOneTransfer)
     uint8_t request_data_after[8] = {5, 7, 0, 0};
     add_crc(request_data_after, sizeof(request_data_after) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data_after, sizeof(request_data_after));
+    scrutiny_handler.receive_data(request_data_after, sizeof(request_data_after));
     scrutiny_handler.process(0);
-    n_to_read = scrutiny_handler.comm()->data_to_send();
+    n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, protocol::CommandId::DataLogControl, 7, protocol::ResponseCode::OK));
 
@@ -906,12 +906,12 @@ TEST_F(TestDatalogControl, TestReadAcquisitionMultipleTransfer)
             uint8_t request_data_after[8] = {5, 7, 0, 0};
             add_crc(request_data_after, sizeof(request_data_after) - 4);
 
-            scrutiny_handler.comm()->receive_data(request_data_after, sizeof(request_data_after));
+            scrutiny_handler.receive_data(request_data_after, sizeof(request_data_after));
             scrutiny_handler.process(0);
-            uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+            uint16_t n_to_read = scrutiny_handler.data_to_send();
             ASSERT_GT(n_to_read, 0) << error_msg;
             ASSERT_LT(n_to_read, sizeof(validation_txbuffer)) << error_msg;
-            scrutiny_handler.comm()->pop_data(validation_txbuffer, n_to_read);
+            scrutiny_handler.pop_data(validation_txbuffer, n_to_read);
             scrutiny_handler.process(0);
 
             ASSERT_TRUE(IS_PROTOCOL_RESPONSE(validation_txbuffer, protocol::CommandId::DataLogControl, 7, protocol::ResponseCode::OK)) << error_msg;
@@ -963,15 +963,15 @@ TEST_F(TestDatalogControl, TestResetDatalogger)
     uint8_t request_data[8] = {5, 8, 0, 0};
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
     fixed_freq_loop.process();
     scrutiny_handler.process(1);
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LE(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
     EXPECT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, protocol::CommandId::DataLogControl, 8, protocol::ResponseCode::OK));
     EXPECT_FALSE(scrutiny_handler.datalogging_ownership_taken());

--- a/test/commands/test_get_info.cpp
+++ b/test/commands/test_get_info.cpp
@@ -64,13 +64,13 @@ TEST_F(TestGetInfo, TestReadprotocolVersion)
     uint8_t expected_response[11] = {0x81, 1, 0, 0, 2, 1, 0}; // Version 1.0
     add_crc(request_data, sizeof(request_data) - 4);
     add_crc(expected_response, sizeof(expected_response) - 4);
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -95,14 +95,14 @@ TEST_F(TestGetInfo, TestReadSoftwareId)
     std::memcpy(&expected_response[5], scrutiny::software_id, SCRUTINY_SOFTWARE_ID_LENGTH);
     add_crc(expected_response, 5 + SCRUTINY_SOFTWARE_ID_LENGTH);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
@@ -139,14 +139,14 @@ TEST_F(TestGetInfo, TestGetSpecialMemoryRegionCount)
     uint8_t expected_response[9 + 2] = {0x81, 4, 0, 0, 2, 2, 1};
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
@@ -205,14 +205,14 @@ TEST_F(TestGetInfo, TestGetSpecialMemoryRegionLocation)
         index_resp += encode_addr(&expected_response[index_resp], reinterpret_cast<void *>(end + i));
         add_crc(expected_response, sizeof(expected_response) - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
         EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-        uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
         EXPECT_EQ(nread, n_to_read) << "i=" << static_cast<uint32_t>(i);
         ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response)) << "i=" << static_cast<uint32_t>(i);
         scrutiny_handler.process(0);
@@ -249,13 +249,13 @@ TEST_F(TestGetInfo, TestGetSpecialMemoryRegionLocation_WrongIndex)
     uint8_t request_data[8 + 2] = {1, 5, 0, 2, 0, 2}; // Oops, index 2 doesn't exist
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, failure));
 }
 
@@ -300,14 +300,14 @@ TEST_F(TestGetInfo, TestGetRPVCount)
     uint8_t expected_response[9 + 2] = {0x81, 6, 0, 0, 2, 0, 3};
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
@@ -346,14 +346,14 @@ TEST_F(TestGetInfo, TestGetRPVDefinition)
 
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
@@ -383,13 +383,13 @@ TEST_F(TestGetInfo, TestGetRPVDefinitionOverflow)
     uint8_t request_data[8 + 4] = {1, 7, 0, 4, 0, 1, 0, 3}; // start=1, count =3.  Will overflow
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, failure));
 }
 
@@ -449,14 +449,14 @@ TEST_F(TestGetInfo, TestSupportedFeatures)
 
         add_crc(expected_response, sizeof(expected_response) - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer)) << "i=" << static_cast<uint32_t>(i);
         EXPECT_EQ(n_to_read, sizeof(expected_response)) << "i=" << static_cast<uint32_t>(i);
 
-        uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
         EXPECT_EQ(nread, n_to_read) << "i=" << static_cast<uint32_t>(i);
         ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response)) << "i=" << static_cast<uint32_t>(i);
     }
@@ -474,14 +474,14 @@ TEST_F(TestGetInfo, TestGetLoopCount)
     expected_response[5] = 3; // 3 loops
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
 
@@ -502,14 +502,14 @@ TEST_F(TestGetInfo, TestGetLoopCountNoLoopSet)
     expected_response[5] = 0; // 2 loops
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
 
@@ -544,14 +544,14 @@ TEST_F(TestGetInfo, TestGetLoopDefinitionFixedFreq)
     scrutiny::tools::strncpy(reinterpret_cast<char *>(&expected_response[13]), loop_name.c_str(), loop_name.size() + 1);
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
 
@@ -582,14 +582,14 @@ TEST_F(TestGetInfo, TestGetLoopDefinitionFixedFreqNoDatalogging)
     scrutiny::tools::strncpy(reinterpret_cast<char *>(&expected_response[13]), loop_name.c_str(), loop_name.size() + 1);
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LE(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
 
@@ -623,13 +623,13 @@ TEST_F(TestGetInfo, TestGetLoopDefinitionVariableFreq)
     scrutiny::tools::strncpy(reinterpret_cast<char *>(&expected_response[9]), loop_name.c_str(), loop_name.size() + 1);
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     ASSERT_GT(n_to_read, 0);
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }

--- a/test/commands/test_memory_control.cpp
+++ b/test/commands/test_memory_control.cpp
@@ -67,15 +67,15 @@ TEST_F(TestMemoryControl, TestReadSingleAddress)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     // Process
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -132,15 +132,15 @@ TEST_F(TestMemoryControl, TestReadMultipleAddress)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     // Processing
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -175,13 +175,13 @@ TEST_F(TestMemoryControl, TestReadAddressInvalidRequest)
         request_data[3] = static_cast<uint8_t>(length_to_test);
         add_crc(request_data, length_to_receive - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, length_to_receive);
+        scrutiny_handler.receive_data(request_data, length_to_receive);
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_GT(n_to_read, 0u) << "[ i=" << static_cast<uint32_t>(i) << "]";
         ASSERT_LT(n_to_read, sizeof(tx_buffer)) << "[i=" << static_cast<uint32_t>(i) << "]";
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
         // Now we expect an InvalidRequest response
         ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, code)) << "[i=" << static_cast<uint32_t>(i) << "]";
         scrutiny_handler.process(0);
@@ -225,12 +225,12 @@ TEST_F(TestMemoryControl, TestReadAddressOverflow)
         request_data[index + 1] = static_cast<uint8_t>(length >> 0);
         add_crc(request_data, length_to_receive - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, length_to_receive);
+        scrutiny_handler.receive_data(request_data, length_to_receive);
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
         if (length < 2) // Below 2, we don't overflow the tx buffer
         {
@@ -283,12 +283,12 @@ TEST_F(TestMemoryControl, TestReadForbiddenAddress)
         request_data[index + 1] = static_cast<uint8_t>(window_size >> 0);
         add_crc(request_data, sizeof(request_data) - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
         if (i < 2 || i > 10) // Sliding window is completely out of forbidden region
         {
@@ -337,12 +337,12 @@ TEST_F(TestMemoryControl, TestReadReadonlyAddress)
         request_data[index + 1] = static_cast<uint8_t>(window_size >> 0);
         add_crc(request_data, sizeof(request_data) - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
         ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, ok)) << "[i=" << static_cast<uint32_t>(i) << "]";
 
@@ -384,15 +384,15 @@ TEST_F(TestMemoryControl, TestWriteSingleAddress)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     // Process
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -434,15 +434,15 @@ TEST_F(TestMemoryControl, TestWriteSingleAddressMasked)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     // Process
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -491,15 +491,15 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddress)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     // Process
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -555,15 +555,15 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddressMasked)
     add_crc(expected_response, sizeof(expected_response) - 4);
 
     // Process
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
@@ -591,14 +591,14 @@ TEST_F(TestMemoryControl, TestWriteSingleAddress_InvalidDataLength)
     add_crc(request_data, sizeof(request_data) - 4);
 
     // Process
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, invalid));
@@ -625,14 +625,14 @@ TEST_F(TestMemoryControl, TestWriteSingleAddressMasked_InvalidDataLength)
     add_crc(request_data, sizeof(request_data) - 4);
 
     // Process
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_GT(n_to_read, 0u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, invalid));
@@ -675,12 +675,12 @@ TEST_F(TestMemoryControl, TestWriteForbiddenAddress)
         // We don't care about the data to write here. We just check if it's accepted or refused.
         add_crc(request_data, sizeof(request_data) - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
         if (i < 2 || i > 10) // Sliding window is completely out of forbidden region
         {
@@ -731,12 +731,12 @@ TEST_F(TestMemoryControl, TestWriteReadOnlyAddress)
         // We don't care about the data to write here. We just check if it's accepted or refused.
         add_crc(request_data, sizeof(request_data) - 4);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
         if (i < 2 || i > 10) // Sliding window is completely out of readonly region
         {
@@ -794,12 +794,12 @@ TEST_F(TestMemoryControl, TestWriteMemoryInvalidRequest)
         request_data[3] = (i >> 0) & 0xFF;
         add_crc(request_data, 4 + i);
 
-        scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+        scrutiny_handler.receive_data(request_data, sizeof(request_data));
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
         ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, invalid)) << "[i=" << static_cast<uint32_t>(i) << "]";
 

--- a/test/commands/test_memory_control_rpv.cpp
+++ b/test/commands/test_memory_control_rpv.cpp
@@ -229,14 +229,14 @@ TEST_F(TestMemoryControlRPV, TestReadSingleRPV)
     uint8_t expected_response[9 + 2 + 4] = {0x83, 4, 0, 0, 2 + 4, 0x11, 0x22, 0x12, 0x34, 0x56, 0x78};
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
@@ -268,14 +268,14 @@ TEST_F(TestMemoryControlRPV, TestReadMultipleRPV)
     uint8_t expected_response[9 + 6 + 4 + 4 + 2] = {0x83, 4, 0, 0, 6 + 4 + 4 + 2, 0x11, 0x22, 0x12, 0x34, 0x56, 0x78, 0x33, 0x44, 0x3f, 0xab, 0x85, 0x1f, 0x55, 0x66, 0xab, 0xcd};
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 }
@@ -338,14 +338,14 @@ TEST_F(TestMemoryControlRPV, TestReadMultipleRPVEachType)
     }
     add_crc(request_data, request_buffer_size - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, request_buffer_size);
+    scrutiny_handler.receive_data(request_data, request_buffer_size);
     scrutiny_handler.process(0);
     delete[] request_data;
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
 
     index = 5;
@@ -391,12 +391,12 @@ TEST_F(TestMemoryControlRPV, TestReadRPVBadRequest)
     uint8_t request_data[8 + 3] = {3, 4, 0, 3, 0x11, 0x22, 0x33}; // Incomplete ID
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, invalid));
 
@@ -428,12 +428,12 @@ TEST_F(TestMemoryControlRPV, TestReadRPVNonExistingID)
     uint8_t request_data[8 + 4] = {3, 4, 0, 4, 0x11, 0x22, 0x99, 0x99}; // 0x9999 doesn't exists
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, failure));
 
@@ -478,13 +478,13 @@ TEST_F(TestMemoryControlRPV, TestReadRPVResponseOverflow)
     // Make request
     add_crc(request_data, request_buffer_size - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, request_buffer_size);
+    scrutiny_handler.receive_data(request_data, request_buffer_size);
     scrutiny_handler.process(0);
     delete[] request_data;
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, overflow));
 
@@ -530,14 +530,14 @@ TEST_F(TestMemoryControlRPV, TestWriteSingleRPV)
     uint8_t expected_response[9 + 2 + 1] = {0x83, 5, 0, 0, 3, 0x10, 0x02, 4}; // id + length
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 
@@ -580,14 +580,14 @@ TEST_F(TestMemoryControlRPV, TestWriteMultipleRPV)
     uint8_t expected_response[9 + 6] = {0x83, 5, 0, 0, (2 + 1) * 2, 0x10, 0x02, 4, 0x10, 0x06, 4};
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
     EXPECT_EQ(n_to_read, sizeof(expected_response));
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
 
@@ -690,13 +690,13 @@ TEST_F(TestMemoryControlRPV, TestWriteAllTypes)
     add_crc(request_data, required_request_size - 4);
     add_crc(expected_response, required_response_size - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, required_request_size);
+    scrutiny_handler.receive_data(request_data, required_request_size);
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     EXPECT_EQ(n_to_read, required_response_size);
 
-    uint16_t nread = scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    uint16_t nread = scrutiny_handler.pop_data(tx_buffer, n_to_read);
     EXPECT_EQ(nread, n_to_read);
     ASSERT_BUF_EQ(tx_buffer, expected_response, required_response_size);
 
@@ -761,13 +761,13 @@ TEST_F(TestMemoryControlRPV, TestWriteRPVBadRequest)
         request_data[3] = i;
         add_crc(request_data, 4 + i);
 
-        scrutiny_handler.comm()->receive_data(request_data, request_size);
+        scrutiny_handler.receive_data(request_data, request_size);
         scrutiny_handler.process(0);
 
-        uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+        uint16_t n_to_read = scrutiny_handler.data_to_send();
         ASSERT_LT(n_to_read, sizeof(tx_buffer)) << " i=" << i;
         ASSERT_EQ(n_to_read, 9u) << " i=" << i;
-        scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+        scrutiny_handler.pop_data(tx_buffer, n_to_read);
         scrutiny_handler.process(0);
 
         ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, invalid)) << " i=" << i;
@@ -821,14 +821,14 @@ TEST_F(TestMemoryControlRPV, TestWriteRPVResponseOverflow)
 
     add_crc(request_data, request_size - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, request_size);
+    scrutiny_handler.receive_data(request_data, request_size);
     scrutiny_handler.process(0);
 
     uint8_t tx_buffer[32];
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_EQ(n_to_read, 9u);
     ASSERT_LT(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
 
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, overflow));
@@ -881,13 +881,13 @@ TEST_F(TestMemoryControlRPV, TestWriteRPVResponseFullNoOverflow)
     add_crc(request_data, request_size - 4);
     add_crc(expected_response, response_size - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, request_size);
+    scrutiny_handler.receive_data(request_data, request_size);
     scrutiny_handler.process(0);
 
     uint8_t tx_buffer[response_size];
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_EQ(n_to_read, sizeof(tx_buffer));
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     scrutiny_handler.process(0);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, response_size);

--- a/test/commands/test_user_command.cpp
+++ b/test/commands/test_user_command.cpp
@@ -79,13 +79,13 @@ TEST_F(TestUserCommand, TestCommandCalled)
     uint8_t expected_response[9 + 4] = {0x84, 0xAA, 0, 0, 4, 0x11, 0x22, 0x33, 0x44};
     add_crc(expected_response, sizeof(expected_response) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
     ASSERT_EQ(n_to_read, sizeof(expected_response));
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     COMPARE_BUF(tx_buffer, expected_response, sizeof(expected_response));
 }
 
@@ -102,12 +102,12 @@ TEST_F(TestUserCommand, TestResponseOverflow)
     uint8_t request_data[8] = {4, 0, 0, 0};
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, 0, code));
 }
 
@@ -124,11 +124,11 @@ TEST_F(TestUserCommand, TestNoCallback)
     uint8_t request_data[8] = {4, 0, 0, 0};
     add_crc(request_data, sizeof(request_data) - 4);
 
-    scrutiny_handler.comm()->receive_data(request_data, sizeof(request_data));
+    scrutiny_handler.receive_data(request_data, sizeof(request_data));
     scrutiny_handler.process(0);
 
-    uint16_t n_to_read = scrutiny_handler.comm()->data_to_send();
+    uint16_t n_to_read = scrutiny_handler.data_to_send();
 
-    scrutiny_handler.comm()->pop_data(tx_buffer, n_to_read);
+    scrutiny_handler.pop_data(tx_buffer, n_to_read);
     ASSERT_TRUE(IS_PROTOCOL_RESPONSE(tx_buffer, cmd, 0, code));
 }


### PR DESCRIPTION
 - Reduce risk of race condition by checking end of transmission right after popping data
 - Updated all examples and tests to use the updated API