### PR TITLE
Fix datalogger timebase

### DIFF
--- a/lib/inc/datalogging/scrutiny_datalogger.hpp
+++ b/lib/inc/datalogging/scrutiny_datalogger.hpp
@@ -52,7 +52,7 @@ namespace scrutiny
                 trigger_callback_t trigger_callback = nullptr);
 
             /// @brief Configure the datalogger with a configuration received by the server
-            /// @param timebase_for_log The timebase used for time logging
+            /// @param timebase The timebase used for time logging & trigger management
             /// @param config_id A configuration ID that will be attached to the acquisition for validation.
             void configure(Timebase *timebase, uint16_t config_id = 0);
 
@@ -133,8 +133,7 @@ namespace scrutiny
             buffer_size_t m_buffer_size;           // The datalogging buffer size
             trigger_callback_t m_trigger_callback; // A function pointer to be called when the trigger trigs. Executed in the owner loop (no thread safety)
 
-            Timebase const *m_timebase;              // Pointer to the timebase for internal time tracking
-            Timebase const *m_timebase_for_log;      // Pointer to timebase for time logging (can be in a different time domain)
+            Timebase const *m_timebase;              // Pointer to the timebase of the owning loop. Used for logging at trigger handling (hold time & timeouts)
             State m_state;                           // Internal state
             timestamp_t m_trigger_timestamp;         // The timestamp at which the trigger happened
             buffer_size_t m_trigger_cursor_location; // Cursor location when trigger point has been recorded

--- a/lib/inc/datalogging/scrutiny_datalogger.hpp
+++ b/lib/inc/datalogging/scrutiny_datalogger.hpp
@@ -42,13 +42,11 @@ namespace scrutiny
 
             /// @brief Initializes the datalogger
             /// @param main_handler A pointer to the main handler to be used to access memory and RPVs
-            /// @param timebase The timebase used to keep track of time
             /// @param buffer The logging buffer
             /// @param buffer_size Size of the logging buffer
             /// @param trigger_callback A function pointer to call when the datalogging trigger condition trigs. Executed in the owner loop (no thread safety)
             void init(
                 MainHandler const *const main_handler,
-                Timebase const *const timebase,
                 uint8_t *const buffer,
                 buffer_size_t const buffer_size,
                 trigger_callback_t trigger_callback = nullptr);
@@ -56,7 +54,7 @@ namespace scrutiny
             /// @brief Configure the datalogger with a configuration received by the server
             /// @param timebase_for_log The timebase used for time logging
             /// @param config_id A configuration ID that will be attached to the acquisition for validation.
-            void configure(Timebase *timebase_for_log, uint16_t config_id = 0);
+            void configure(Timebase *timebase, uint16_t config_id = 0);
 
             /// @brief Periodic process. To be called as fast as possible
             void process(void);

--- a/lib/inc/datalogging/scrutiny_datalogger_raw_encoder.hpp
+++ b/lib/inc/datalogging/scrutiny_datalogger_raw_encoder.hpp
@@ -69,7 +69,7 @@ namespace scrutiny
             void encode_next_entry(void);
             void reset(void);
             inline void reset_write_counter(void) { m_entry_write_counter = 0; }
-            inline void set_timebase(Timebase const *const timebase_for_log) { m_timebase_for_log = timebase_for_log; }
+            inline void set_timebase(Timebase const *const timebase) { m_timebase = timebase; }
             inline datalogging::buffer_size_t get_entry_write_counter(void) const { return m_entry_write_counter; }
             inline datalogging::buffer_size_t get_data_write_counter(void) const { return m_entry_write_counter * m_entry_size; }
             inline datalogging::EncodingType get_encoding(void) const { return ENCODING; }
@@ -92,7 +92,7 @@ namespace scrutiny
             datalogging::Configuration const *m_config = nullptr;
             RawFormatReader m_reader;
             MainHandler const *m_main_handler = nullptr;
-            Timebase const *m_timebase_for_log = nullptr;
+            Timebase const *m_timebase = nullptr;
 
             datalogging::buffer_size_t m_max_entries = 0;
             datalogging::buffer_size_t m_next_entry_write_index = 0;

--- a/lib/inc/datalogging/scrutiny_datalogger_raw_encoder.hpp
+++ b/lib/inc/datalogging/scrutiny_datalogger_raw_encoder.hpp
@@ -63,13 +63,13 @@ namespace scrutiny
 
             void init(
                 MainHandler const *const main_handler,
-                Timebase const *const timebase,
                 datalogging::Configuration const *const config,
                 uint8_t *const buffer,
                 datalogging::buffer_size_t const buffer_size);
             void encode_next_entry(void);
             void reset(void);
             inline void reset_write_counter(void) { m_entry_write_counter = 0; }
+            inline void set_timebase(Timebase const *const timebase_for_log) { m_timebase_for_log = timebase_for_log; }
             inline datalogging::buffer_size_t get_entry_write_counter(void) const { return m_entry_write_counter; }
             inline datalogging::buffer_size_t get_data_write_counter(void) const { return m_entry_write_counter * m_entry_size; }
             inline datalogging::EncodingType get_encoding(void) const { return ENCODING; }

--- a/lib/src/datalogging/scrutiny_datalogger.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger.cpp
@@ -23,17 +23,16 @@ namespace scrutiny
     {
         void DataLogger::init(
             MainHandler const *const main_handler,
-            Timebase const *const timebase,
             uint8_t *const buffer,
             buffer_size_t const buffer_size,
             trigger_callback_t trigger_callback)
         {
-            m_timebase = timebase;
+            m_timebase = nullptr;
             m_main_handler = main_handler;
             m_buffer_size = buffer_size;
             m_trigger_callback = trigger_callback;
 
-            m_encoder.init(main_handler, timebase, &m_config, buffer, buffer_size);
+            m_encoder.init(main_handler, &m_config, buffer, buffer_size);
             m_acquisition_id = 0;
 
             reset();
@@ -56,12 +55,12 @@ namespace scrutiny
             m_log_points_after_trigger = 0;
         }
 
-        void DataLogger::configure(Timebase *timebase_for_log, uint16_t config_id)
+        void DataLogger::configure(Timebase *timebase, uint16_t config_id)
         {
             reset();
 
             m_config_valid = true;
-            m_timebase_for_log = timebase_for_log;
+            m_timebase = timebase;
             m_config_id = config_id;
 
             if (m_config.items_count > SCRUTINY_DATALOGGING_MAX_SIGNAL || m_config.items_count == 0)
@@ -200,6 +199,7 @@ namespace scrutiny
             // The configuration is good. Let's initialize to do an start logging
             if (m_config_valid)
             {
+                m_encoder.set_timebase(m_timebase);
                 m_trigger.active_condition->reset(m_trigger.conditions.data());
                 m_encoder.reset();
                 m_state = State::CONFIGURED;

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -125,6 +125,8 @@ namespace scrutiny
                 }
                 else if (m_config->items_to_log[i].type == datalogging::LoggableType::TIME)
                 {
+                    // No check for m_timebase_for_log == nullptr.
+                    // Expect the datalogger to set it.
                     codecs::encode_32_bits_big_endian(m_timebase_for_log->get_timestamp(), &m_buffer[cursor]);
                     cursor += sizeof(scrutiny::timestamp_t);
                 }
@@ -148,13 +150,11 @@ namespace scrutiny
         /// @brief  Init the encoder
         void RawFormatEncoder::init(
             MainHandler const *const main_handler,
-            Timebase const *const timebase_for_log,
             datalogging::Configuration const *const config,
             uint8_t *const buffer,
             datalogging::buffer_size_t const buffer_size)
         {
             m_main_handler = main_handler;
-            m_timebase_for_log = timebase_for_log;
             m_config = config;
             m_buffer = buffer;
             m_buffer_size = buffer_size;

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -125,9 +125,9 @@ namespace scrutiny
                 }
                 else if (m_config->items_to_log[i].type == datalogging::LoggableType::TIME)
                 {
-                    // No check for m_timebase_for_log == nullptr.
+                    // No check for m_timebase == nullptr.
                     // Expect the datalogger to set it.
-                    codecs::encode_32_bits_big_endian(m_timebase_for_log->get_timestamp(), &m_buffer[cursor]);
+                    codecs::encode_32_bits_big_endian(m_timebase->get_timestamp(), &m_buffer[cursor]);
                     cursor += sizeof(scrutiny::timestamp_t);
                 }
             }

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -61,7 +61,7 @@ namespace scrutiny
         }
 
 #if SCRUTINY_ENABLE_DATALOGGING
-        m_datalogging.datalogger.init(this, &m_timebase, m_config.m_datalogger_buffer, m_config.m_datalogger_buffer_size, m_config.m_datalogger_trigger_callback);
+        m_datalogging.datalogger.init(this, m_config.m_datalogger_buffer, m_config.m_datalogger_buffer_size, m_config.m_datalogger_trigger_callback);
         m_datalogging.owner = nullptr;
         m_datalogging.new_owner = nullptr;
         m_datalogging.error = DataloggingError::NoError;
@@ -312,7 +312,7 @@ namespace scrutiny
             break;
         }
     }
-    
+
     void MainHandler::process_datalogging_logic(void)
     {
         if (m_datalogging.error != DataloggingError::NoError)

--- a/test/datalogging/test_raw_encoder.cpp
+++ b/test/datalogging/test_raw_encoder.cpp
@@ -88,7 +88,8 @@ TEST_F(TestRawEncoder, BasicEncoding)
 
     dlconfig.items_to_log[2].type = datalogging::LoggableType::TIME;
 
-    encoder.init(&scrutiny_handler, &timebase, &dlconfig, dlbuffer, sizeof(dlbuffer));
+    encoder.init(&scrutiny_handler, &dlconfig, dlbuffer, sizeof(dlbuffer));
+    encoder.set_timebase(&timebase);
     timebase.reset();
 
     var1 = 1.0f;


### PR DESCRIPTION
1. Passes the timebase down to the encoder.
2. Uses the owner timebase for trigger management too. No more need for 2 time bases in the datalogger