### PR TITLE
C2000 Endianess fix

### DIFF
--- a/lib/inc/scrutiny_common_codecs.hpp
+++ b/lib/inc/scrutiny_common_codecs.hpp
@@ -91,16 +91,8 @@ namespace scrutiny
 #if CHAR_BIT == 8
             return encode_32_bits_big_endian_8bits(value, buff);
 #elif CHAR_BIT == 16
-            if (tools::is_little_endian())
-            {
-                buff[0] = (static_cast<unsigned char>((value >> 8) & 0xFF00)) | (static_cast<unsigned char>((value >> 24) & 0xFFu));
-                buff[1] = (static_cast<unsigned char>((value >> 0) & 0xFF00)) | (static_cast<unsigned char>((value >> 16) & 0xFFu));
-            }
-            else
-            {
-                buff[0] = static_cast<unsigned char>((value >> 16) & 0xFFFF);
-                buff[1] = static_cast<unsigned char>(value & 0xFFFF);
-            }
+            buff[0] = static_cast<unsigned char>((value >> 16) & 0xFFFF);
+            buff[1] = static_cast<unsigned char>(value & 0xFFFF);
             return 2;
 #else
 #error

--- a/lib/inc/scrutiny_common_codecs.hpp
+++ b/lib/inc/scrutiny_common_codecs.hpp
@@ -21,6 +21,7 @@ namespace scrutiny
         // =============================
         // =========== ENCODE ==========
         // =============================
+
         inline uint_least8_t encode_8_bits_8bits(uint_least8_t const value, unsigned char *const buff)
         {
             buff[0] = static_cast<unsigned char>(value & 0xFFu);
@@ -90,8 +91,16 @@ namespace scrutiny
 #if CHAR_BIT == 8
             return encode_32_bits_big_endian_8bits(value, buff);
 #elif CHAR_BIT == 16
-            buff[0] = static_cast<unsigned char>((value >> 16) & 0xFFFF);
-            buff[1] = static_cast<unsigned char>(value & 0xFFFF);
+            if (tools::is_little_endian())
+            {
+                buff[0] = (static_cast<unsigned char>((value >> 8) & 0xFF00)) | (static_cast<unsigned char>((value >> 24) & 0xFFu));
+                buff[1] = (static_cast<unsigned char>((value >> 0) & 0xFF00)) | (static_cast<unsigned char>((value >> 16) & 0xFFu));
+            }
+            else
+            {
+                buff[0] = static_cast<unsigned char>((value >> 16) & 0xFFFF);
+                buff[1] = static_cast<unsigned char>(value & 0xFFFF);
+            }
             return 2;
 #else
 #error

--- a/lib/inc/scrutiny_compiler.hpp
+++ b/lib/inc/scrutiny_compiler.hpp
@@ -27,6 +27,7 @@
 #define SCRUTINY_FINAL final
 #define SCRUTINY_EXPLICIT explicit
 #define SCRUTINY_NULL_FN_PTR(t) nullptr
+#define SCRUTINY_CONSTEXPR_FUNC constexpr
 #else
 #define SCRUTINY_CONSTEXPR const
 #define SCRUTINY_ENUM(name, type) enum name
@@ -36,6 +37,7 @@
 #define SCRUTINY_FINAL
 #define SCRUTINY_EXPLICIT
 #define SCRUTINY_NULL_FN_PTR(t) reinterpret_cast<t>(NULL)
+#define SCRUTINY_CONSTEXPR_FUNC
 #endif
 
 // ========== Platform detection ==========

--- a/lib/inc/scrutiny_tools.hpp
+++ b/lib/inc/scrutiny_tools.hpp
@@ -308,9 +308,9 @@ namespace scrutiny
         inline bool is_float_finite(float const val)
         {
 #if SCRUTINY_BUILD_AVR_GCC || SCRUTINY_BUILD_TI_C28
-            SCRUTINY_STATIC_ASSERT(sizeof(float) == 4, "Expect float to be 32 bits");
+            SCRUTINY_STATIC_ASSERT(sizeof(float) == sizeof(uint32_t), "Expect float to be 32 bits");
             uint32_t uv;
-            memcpy(&uv, &val, 4);
+            memcpy(&uv, &val, sizeof(uint32_t));
             uint16_t exponent = (uv >> 23) & 0xFF;
             return exponent != 0xFF;
 #else
@@ -323,11 +323,20 @@ namespace scrutiny
 #if CHAR_BIT == 8
             memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
+#if SCRUTINY_BUILD_TI_C28
             for (size_t i = 0; i < (nb_8bits >> 1); i++)
             {
+#if __little_endian__ || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
+                static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
+                static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
+#else
                 static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
                 static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
+#endif
             }
+#else
+#error "16bits on non C2000 target requires to be handled here."
+#endif
 #else
 #error
 #endif
@@ -338,11 +347,20 @@ namespace scrutiny
 #if CHAR_BIT == 8
             memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
+#if #if SCRUTINY_BUILD_TI_C28
             for (size_t i = 0; i < (nb_8bits >> 1); i++)
             {
+#if __little_endian__ || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
+                static_cast<unsigned char *>(dst)[i] =
+                    (((static_cast<unsigned char const *>(src)[2 * i + 1] & 0xFF) << 8) | (static_cast<unsigned char const *>(src)[2 * i] & 0xFF));
+#else
                 static_cast<unsigned char *>(dst)[i] =
                     (((static_cast<unsigned char const *>(src)[2 * i] & 0xFF) << 8) | (static_cast<unsigned char const *>(src)[2 * i + 1] & 0xFF));
+#endif
             }
+#else
+#error "16bits on non C2000 target requires to be handled here."
+#endif
 #else
 #error
 #endif

--- a/lib/inc/scrutiny_tools.hpp
+++ b/lib/inc/scrutiny_tools.hpp
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "scrutiny_compiler.hpp"
 #include "scrutiny_setup.hpp"
 #include "scrutiny_types.hpp"
 
@@ -27,6 +28,31 @@ namespace scrutiny
 {
     namespace tools
     {
+        inline bool is_little_endian(void)
+        {
+#if SCRUTINY_BUILD_TI_C28
+#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
+            return true;
+#else
+            return false;
+#endif
+#elif (defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__ == 1) || (defined(_LITTLE_ENDIAN) && _LITTLE_ENDIAN == 1)
+            return true;
+#elif (defined(__BIG_ENDIAN__) && __BIG_ENDIAN__ == 1) || (defined(_BIG_ENDIAN) && _BIG_ENDIAN == 1)
+            return false;
+#else
+            // Runtime check. Should get optimized.
+            SCRUTINY_CONSTEXPR uint32_t x = 0x12345678;
+#if CHAR_BIT == 8
+            return *reinterpret_cast<unsigned char const *>(&x) == 0x78;
+#elif CHAR_BIT == 16
+            return *reinterpret_cast<unsigned char const *>(&x) == 0x5678;
+#else
+#error
+#endif
+#endif
+        }
+
         /// @brief Returns true if the type is supported by scrutiny
         bool is_supported_type(VariableType::eVariableType const vt);
 
@@ -364,15 +390,14 @@ namespace scrutiny
 #if CHAR_BIT == 8
             memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
-#if SCRUTINY_BUILD_TI_C28
-#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
-            memcpy_dilate_8bits_little_endian(dst, src, nb_8bits);
-#else
-            memcpy_dilate_8bits_big_endian(dst, src, nb_8bits);
-#endif
-#else
-#error "16bits on non C2000 target requires to be handled here."
-#endif
+            if (is_little_endian())
+            {
+                memcpy_dilate_8bits_little_endian(dst, src, nb_8bits);
+            }
+            else
+            {
+                memcpy_dilate_8bits_big_endian(dst, src, nb_8bits);
+            }
 #endif
         }
 
@@ -422,18 +447,14 @@ namespace scrutiny
 #if CHAR_BIT == 8
             memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
-#if SCRUTINY_BUILD_TI_C28
-#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
-            memcpy_compress_from_8bits_little_endian(dst, src, nb_8bits);
-#else
-            memcpy_compress_from_8bits_big_endian(dst, src, nb_8bits);
-#endif
-
-#else
-#error "16bits on non C2000 target requires to be handled here."
-#endif
-#else
-#error
+            if (is_little_endian())
+            {
+                memcpy_compress_from_8bits_little_endian(dst, src, nb_8bits);
+            }
+            else
+            {
+                memcpy_compress_from_8bits_big_endian(dst, src, nb_8bits);
+            }
 #endif
         }
 

--- a/lib/inc/scrutiny_tools.hpp
+++ b/lib/inc/scrutiny_tools.hpp
@@ -326,7 +326,7 @@ namespace scrutiny
 #if SCRUTINY_BUILD_TI_C28
             for (size_t i = 0; i < (nb_8bits >> 1); i++)
             {
-#if __little_endian__ || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
+#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
                 static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
                 static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
 #else
@@ -350,7 +350,7 @@ namespace scrutiny
 #if #if SCRUTINY_BUILD_TI_C28
             for (size_t i = 0; i < (nb_8bits >> 1); i++)
             {
-#if __little_endian__ || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
+#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
                 static_cast<unsigned char *>(dst)[i] =
                     (((static_cast<unsigned char const *>(src)[2 * i + 1] & 0xFF) << 8) | (static_cast<unsigned char const *>(src)[2 * i] & 0xFF));
 #else

--- a/lib/inc/scrutiny_tools.hpp
+++ b/lib/inc/scrutiny_tools.hpp
@@ -318,46 +318,117 @@ namespace scrutiny
 #endif
         }
 
-        inline void memcpy_dilate_8bits(void *const dst, void const *const src, size_t const nb_8bits)
+        /// @brief Take an array of char and copy to a destination buffer, making sure that there is only 8bits per char.
+        /// tarnslate to a memcpy on most platforms. Different behavior for 16bits char. Use big endianness
+        /// @param dst Destination buffer
+        /// @param src Source buffer
+        /// @param nb_8bits Number of char in the destination buffer to write.
+        inline void memcpy_dilate_8bits_big_endian(void *const dst, void const *const src, size_t const nb_8bits)
         {
 #if CHAR_BIT == 8
             memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
-#if SCRUTINY_BUILD_TI_C28
             for (size_t i = 0; i < (nb_8bits >> 1); i++)
             {
-#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
-                static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
-                static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
-#else
                 static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
                 static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
-#endif
             }
-#else
-#error "16bits on non C2000 target requires to be handled here."
-#endif
-#else
-#error
 #endif
         }
 
-        inline void memcpy_compress_from_8bits(void *const dst, void const *const src, size_t const nb_8bits)
+        /// @brief Take an array of char and copy to a destination buffer, making sure that there is only 8bits per char.
+        /// tarnslate to a memcpy on most platforms. Different behavior for 16bits char. Use little endianness
+        /// @param dst Destination buffer
+        /// @param src Source buffer
+        /// @param nb_8bits Number of char in the destination buffer to write.
+        inline void memcpy_dilate_8bits_little_endian(void *const dst, void const *const src, size_t const nb_8bits)
+        {
+#if CHAR_BIT == 8
+            memcpy(dst, src, nb_8bits);
+#elif CHAR_BIT == 16
+            for (size_t i = 0; i < (nb_8bits >> 1); i++)
+            {
+                static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
+                static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
+            }
+#endif
+        }
+
+        /// @brief Take an array of char and copy to a destination buffer, making sure that there is only 8bits per char.
+        /// tarnslate to a memcpy on most platforms. Different behavior for 16bits char. Use target endianness
+        /// @param dst Destination buffer
+        /// @param src Source buffer
+        /// @param nb_8bits Number of char in the destination buffer to write.
+        inline void memcpy_dilate_8bits_native(void *const dst, void const *const src, size_t const nb_8bits)
         {
 #if CHAR_BIT == 8
             memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
 #if SCRUTINY_BUILD_TI_C28
+#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
+            memcpy_dilate_8bits_little_endian(dst, src, nb_8bits);
+#else
+            memcpy_dilate_8bits_big_endian(dst, src, nb_8bits);
+#endif
+#else
+#error "16bits on non C2000 target requires to be handled here."
+#endif
+#endif
+        }
+
+        /// @brief Copy a buffer that has 8bits per char into a buffer that has CHAR_BIT bits per char. For most platforms
+        /// this translates to a memcpy. Different behavior for 16bits char. Uses big endianness
+        /// @param dst Destination buffer
+        /// @param src Source buffer
+        /// @param nb_8bits Number of char in the source buffer
+        inline void memcpy_compress_from_8bits_big_endian(void *const dst, void const *const src, size_t const nb_8bits)
+        {
+#if CHAR_BIT == 8
+            memcpy(dst, src, nb_8bits);
+#elif CHAR_BIT == 16
             for (size_t i = 0; i < (nb_8bits >> 1); i++)
             {
-#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
-                static_cast<unsigned char *>(dst)[i] =
-                    (((static_cast<unsigned char const *>(src)[2 * i + 1] & 0xFF) << 8) | (static_cast<unsigned char const *>(src)[2 * i] & 0xFF));
-#else
                 static_cast<unsigned char *>(dst)[i] =
                     (((static_cast<unsigned char const *>(src)[2 * i] & 0xFF) << 8) | (static_cast<unsigned char const *>(src)[2 * i + 1] & 0xFF));
-#endif
             }
+#endif
+        }
+
+        /// @brief Copy a buffer that has 8bits per char into a buffer that has CHAR_BIT bits per char. For most platforms
+        /// this translates to a memcpy. Different behavior for 16bits char. Uses little endianness
+        /// @param dst Destination buffer
+        /// @param src Source buffer
+        /// @param nb_8bits Number of char in the source buffer
+        inline void memcpy_compress_from_8bits_little_endian(void *const dst, void const *const src, size_t const nb_8bits)
+        {
+#if CHAR_BIT == 8
+            memcpy(dst, src, nb_8bits);
+#elif CHAR_BIT == 16
+            for (size_t i = 0; i < (nb_8bits >> 1); i++)
+            {
+                static_cast<unsigned char *>(dst)[i] =
+                    (((static_cast<unsigned char const *>(src)[2 * i + 1] & 0xFF) << 8) | (static_cast<unsigned char const *>(src)[2 * i] & 0xFF));
+            }
+#endif
+        }
+
+        /// @brief Copy a buffer that has 8bits per char into a buffer that has CHAR_BIT bits per char. For most platforms
+        /// this translates to a memcpy. Different behavior for 16bits char. Uses target endianness
+        /// @param dst Destination buffer
+        /// @param src Source buffer
+        /// @param nb_8bits Number of char in the source buffer
+        inline void memcpy_compress_from_8bits_native(void *const dst, void const *const src, size_t const nb_8bits)
+        {
+#if CHAR_BIT == 8
+            memcpy(dst, src, nb_8bits);
+#elif CHAR_BIT == 16
+#if SCRUTINY_BUILD_TI_C28
+#if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler
+            memcpy_compress_from_8bits_little_endian(dst, src, nb_8bits);
+#else
+            memcpy_compress_from_8bits_big_endian(dst, src, nb_8bits);
+#endif
+
 #else
 #error "16bits on non C2000 target requires to be handled here."
 #endif

--- a/lib/inc/scrutiny_tools.hpp
+++ b/lib/inc/scrutiny_tools.hpp
@@ -347,7 +347,7 @@ namespace scrutiny
 #if CHAR_BIT == 8
             memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
-#if #if SCRUTINY_BUILD_TI_C28
+#if SCRUTINY_BUILD_TI_C28
             for (size_t i = 0; i < (nb_8bits >> 1); i++)
             {
 #if (defined(__little_endian__) && __little_endian__) || defined(_LITTLE_ENDIAN_) // Those macros are defined by the C2000 compiler

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -172,7 +172,9 @@ namespace scrutiny
                 {
                     // No check for m_timebase == nullptr.
                     // Expect the datalogger to set it.
-                    codecs::encode_32_bits_big_endian_char(m_timebase->get_timestamp(), &m_buffer[cursor]);
+                    unsigned char tmp[4];
+                    codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), &tmp);
+                    tools::memcpy_compress_from_8bits_big_endian(&m_buffer[cursor], tmp);
                     cursor += sizeof(scrutiny::timestamp_t);
                 }
             }

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -126,6 +126,9 @@ namespace scrutiny
         /// @brief Takes a snapshot of the data to log and write it into the datalogger buffer
         void RawFormatEncoder::encode_next_entry(LoopHandler *const caller)
         {
+#if CHAR_BIT==16            
+            unsigned char tmp [sizeof(scrutiny::uint_biggest_t) * (CHAR_BIT/8)];
+#endif            
             if (m_error)
             {
                 return;
@@ -166,15 +169,28 @@ namespace scrutiny
                     {
                         tools::set_biggest_uint(outval, 0);
                     }
+#if CHAR_BIT == 8                    
                     cursor += codecs::encode_anytype_big_endian_char(&outval, rpv.type, &m_buffer[cursor]);
+#elif CHAR_BIT == 16
+                    uint16_t nb_8bits = codecs::encode_anytype_big_endian_8bits(&outval, rpv.type, tmp);
+                    tools::memcpy_compress_from_8bits_native(&m_buffer[cursor], tmp, nb_8bits);
+                    cursor += nb_8bits / (CHAR_BIT/8);
+#endif
                 }
                 else if (m_config->items_to_log[i].type == datalogging::LoggableType::Time)
                 {
                     // No check for m_timebase == nullptr.
                     // Expect the datalogger to set it.
-                    unsigned char tmp[4];
+#if CHAR_BIT == 8
+                    codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), &m_buffer[cursor], sizeof(uint32_t));
+#elif CHAR_BIT == 16    
+                    // Here we handle the case where databist are little endian within a single char.
+                    // Only relaible way is toe extract each 8bits nibble and reencode like we want.
+                    // Since read_dialte_8bits do a dilate_native, we encode with 8bits_native.
                     codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), tmp);
-                    tools::memcpy_compress_from_8bits_big_endian(&m_buffer[cursor], tmp, 4);
+                    tools::memcpy_compress_from_8bits_native(&m_buffer[cursor], tmp, sizeof(uint32_t) * (CHAR_BIT/8));
+#endif
+                    
                     cursor += sizeof(scrutiny::timestamp_t);
                 }
             }

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -172,9 +172,7 @@ namespace scrutiny
                 {
                     // No check for m_timebase == nullptr.
                     // Expect the datalogger to set it.
-                    unsigned char tmp[4];
-                    codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), &tmp);
-                    tools::memcpy_compress_from_8bits_big_endian(&m_buffer[cursor], tmp);
+                    codecs::encode_32_bits_big_endian_char(m_timebase->get_timestamp(), &m_buffer[cursor]);
                     cursor += sizeof(scrutiny::timestamp_t);
                 }
             }

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -126,9 +126,9 @@ namespace scrutiny
         /// @brief Takes a snapshot of the data to log and write it into the datalogger buffer
         void RawFormatEncoder::encode_next_entry(LoopHandler *const caller)
         {
-#if CHAR_BIT==16            
-            unsigned char tmp [sizeof(scrutiny::uint_biggest_t) * (CHAR_BIT/8)];
-#endif            
+#if CHAR_BIT == 16
+            unsigned char tmp[sizeof(scrutiny::uint_biggest_t) * (CHAR_BIT / 8)];
+#endif
             if (m_error)
             {
                 return;
@@ -169,12 +169,12 @@ namespace scrutiny
                     {
                         tools::set_biggest_uint(outval, 0);
                     }
-#if CHAR_BIT == 8                    
+#if CHAR_BIT == 8
                     cursor += codecs::encode_anytype_big_endian_char(&outval, rpv.type, &m_buffer[cursor]);
 #elif CHAR_BIT == 16
                     uint16_t nb_8bits = codecs::encode_anytype_big_endian_8bits(&outval, rpv.type, tmp);
                     tools::memcpy_compress_from_8bits_native(&m_buffer[cursor], tmp, nb_8bits);
-                    cursor += nb_8bits / (CHAR_BIT/8);
+                    cursor += nb_8bits / (CHAR_BIT / 8);
 #endif
                 }
                 else if (m_config->items_to_log[i].type == datalogging::LoggableType::Time)
@@ -183,14 +183,14 @@ namespace scrutiny
                     // Expect the datalogger to set it.
 #if CHAR_BIT == 8
                     codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), &m_buffer[cursor], sizeof(uint32_t));
-#elif CHAR_BIT == 16    
+#elif CHAR_BIT == 16
                     // Here we handle the case where databist are little endian within a single char.
                     // Only relaible way is toe extract each 8bits nibble and reencode like we want.
                     // Since read_dialte_8bits do a dilate_native, we encode with 8bits_native.
                     codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), tmp);
-                    tools::memcpy_compress_from_8bits_native(&m_buffer[cursor], tmp, sizeof(uint32_t) * (CHAR_BIT/8));
+                    tools::memcpy_compress_from_8bits_native(&m_buffer[cursor], tmp, sizeof(uint32_t) * (CHAR_BIT / 8));
 #endif
-                    
+
                     cursor += sizeof(scrutiny::timestamp_t);
                 }
             }

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -172,7 +172,9 @@ namespace scrutiny
                 {
                     // No check for m_timebase == nullptr.
                     // Expect the datalogger to set it.
-                    codecs::encode_32_bits_big_endian_char(m_timebase->get_timestamp(), &m_buffer[cursor]);
+                    unsigned char tmp[4];
+                    codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), tmp);
+                    tools::memcpy_compress_from_8bits_big_endian(&m_buffer[cursor], tmp, 4);
                     cursor += sizeof(scrutiny::timestamp_t);
                 }
             }

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -172,6 +172,9 @@ namespace scrutiny
 #if CHAR_BIT == 8
                     cursor += codecs::encode_anytype_big_endian_char(&outval, rpv.type, &m_buffer[cursor]);
 #elif CHAR_BIT == 16
+                    // Here we handle the case where data bits are little endian within a single char.
+                    // We do a little work to put that in a usable format in every sample so we can dump fast
+                    // when the server request to read.
                     uint16_t nb_8bits = codecs::encode_anytype_big_endian_8bits(&outval, rpv.type, tmp);
                     tools::memcpy_compress_from_8bits_native(&m_buffer[cursor], tmp, nb_8bits);
                     cursor += nb_8bits / (CHAR_BIT / 8);
@@ -184,9 +187,9 @@ namespace scrutiny
 #if CHAR_BIT == 8
                     codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), &m_buffer[cursor]);
 #elif CHAR_BIT == 16
-                    // Here we handle the case where databist are little endian within a single char.
-                    // Only relaible way is toe extract each 8bits nibble and reencode like we want.
-                    // Since read_dialte_8bits do a dilate_native, we encode with 8bits_native.
+                    // Here we handle the case where data bits are little endian within a single char.
+                    // We do a little work to put that in a usable format in every sample so we can dump fast
+                    // when the server request to read.
                     codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), tmp);
                     tools::memcpy_compress_from_8bits_native(&m_buffer[cursor], tmp, sizeof(uint32_t) * (CHAR_BIT / 8));
 #endif
@@ -250,7 +253,7 @@ namespace scrutiny
                 uint_fast8_t elem_size = 0;
                 if (m_config->items_to_log[i].type == datalogging::LoggableType::Memory)
                 {
-                    elem_size = m_config->items_to_log[i].data.memory.size; // Size if char
+                    elem_size = m_config->items_to_log[i].data.memory.size; // Size in char
                 }
                 else if (m_config->items_to_log[i].type == datalogging::LoggableType::Rpv)
                 {
@@ -262,12 +265,12 @@ namespace scrutiny
                     }
                     else
                     {
-                        elem_size = tools::get_type_size_char(rpv.type); // Size if char
+                        elem_size = tools::get_type_size_char(rpv.type); // Size in char
                     }
                 }
                 else if (m_config->items_to_log[i].type == datalogging::LoggableType::Time)
                 {
-                    elem_size = sizeof(scrutiny::timestamp_t); // Size if char
+                    elem_size = sizeof(scrutiny::timestamp_t); // Size in char
                 }
 
                 if (elem_size == 0 && !m_error)

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -182,7 +182,7 @@ namespace scrutiny
                     // No check for m_timebase == nullptr.
                     // Expect the datalogger to set it.
 #if CHAR_BIT == 8
-                    codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), &m_buffer[cursor], sizeof(uint32_t));
+                    codecs::encode_32_bits_big_endian_8bits(m_timebase->get_timestamp(), &m_buffer[cursor]);
 #elif CHAR_BIT == 16
                     // Here we handle the case where databist are little endian within a single char.
                     // Only relaible way is toe extract each 8bits nibble and reencode like we want.

--- a/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger_raw_encoder.cpp
@@ -64,7 +64,7 @@ namespace scrutiny
                 datalogging::buffer_size_t const right_hand_start_point = (write_cursor > m_read_cursor) ? write_cursor : buffer_end;
                 transfer_size_8bits = (right_hand_start_point - m_read_cursor) * (CHAR_BIT / 8);
                 transfer_size_8bits = SCRUTINY_MIN(transfer_size_8bits, new_max_8bits);
-                tools::memcpy_dilate_8bits(&buffer_8bits[output_cursor_8bits], &m_encoder->m_buffer[m_read_cursor], transfer_size_8bits);
+                tools::memcpy_dilate_8bits_native(&buffer_8bits[output_cursor_8bits], &m_encoder->m_buffer[m_read_cursor], transfer_size_8bits);
                 m_read_cursor += transfer_size_8bits / (CHAR_BIT / 8);
                 m_read_started = true;
                 output_cursor_8bits += transfer_size_8bits;

--- a/lib/src/protocol/scrutiny_codec_v1_0.cpp
+++ b/lib/src/protocol/scrutiny_codec_v1_0.cpp
@@ -268,7 +268,7 @@ namespace scrutiny
 
             m_cursor += codecs::encode_address_big_endian_8bits(memblock_8bits->start_address, &m_buffer[m_cursor]);
             m_cursor += codecs::encode_16_bits_big_endian_8bits(memblock_8bits->length, &m_buffer[m_cursor]);
-            tools::memcpy_dilate_8bits(&m_buffer[m_cursor], memblock_8bits->start_address, memblock_8bits->length);
+            tools::memcpy_dilate_8bits_native(&m_buffer[m_cursor], memblock_8bits->start_address, memblock_8bits->length);
             m_cursor += memblock_8bits->length;
 
             m_response->data_length = m_cursor;
@@ -593,7 +593,7 @@ namespace scrutiny
             }
 
             response->data_length = datalen;
-            tools::memcpy_dilate_8bits(response->data, scrutiny::software_id, SIZEOF_8BITS(scrutiny::software_id));
+            tools::memcpy_dilate_8bits_big_endian(response->data, scrutiny::software_id, SIZEOF_8BITS(scrutiny::software_id));
             return ResponseCode::OK;
         }
 
@@ -838,7 +838,7 @@ namespace scrutiny
             response->data_length = proto_maj_size + proto_min_size + software_id_size + display_name_length_size + display_name_length;
             response->data[proto_maj_pos] = SCRUTINY_PROTOCOL_VERSION_MAJOR(SCRUTINY_ACTUAL_PROTOCOL_VERSION);
             response->data[proto_min_pos] = SCRUTINY_PROTOCOL_VERSION_MINOR(SCRUTINY_ACTUAL_PROTOCOL_VERSION);
-            tools::memcpy_dilate_8bits(&response->data[firmware_id_pos], scrutiny::software_id, software_id_size);
+            tools::memcpy_dilate_8bits_big_endian(&response->data[firmware_id_pos], scrutiny::software_id, software_id_size);
             response->data[display_name_length_pos] = static_cast<unsigned char>(display_name_length & 0xFF);
             memcpy(&response->data[display_name_pos], response_data->display_name, display_name_length);
             return ResponseCode::OK;

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -1182,8 +1182,18 @@ namespace scrutiny
                         temp |= (stack.write_mem.block.source_data[i] & stack.write_mem.block.mask[i]);    // Bit to 1
                         temp &= (stack.write_mem.block.source_data[i] | (~stack.write_mem.block.mask[i])); // Bit to 0
 #elif CHAR_BIT == 16
-                        unsigned char const val16bits = codecs::decode_16_bits_big_endian_8bits(&stack.write_mem.block.source_data[2 * i]);
-                        unsigned char const mask16bits = codecs::decode_16_bits_big_endian_8bits(&stack.write_mem.block.mask[2 * i]);
+                        unsigned char val16bits;
+                        unsigned char mask16bits;
+                        if (tools::is_little_endian())
+                        {
+                            val16bits = codecs::decode_16_bits_little_endian_8bits(&stack.write_mem.block.source_data[2 * i]);
+                            mask16bits = codecs::decode_16_bits_little_endian_8bits(&stack.write_mem.block.mask[2 * i]);
+                        }
+                        else
+                        {
+                            val16bits = codecs::decode_16_bits_big_endian_8bits(&stack.write_mem.block.source_data[2 * i]);
+                            mask16bits = codecs::decode_16_bits_big_endian_8bits(&stack.write_mem.block.mask[2 * i]);
+                        }
                         temp |= (val16bits & mask16bits);    // Bit to 1
                         temp &= (val16bits | (~mask16bits)); // Bit to 0
 #else

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -1167,7 +1167,7 @@ namespace scrutiny
 
                 if (!masked)
                 {
-                    tools::memcpy_compress_from_8bits(
+                    tools::memcpy_compress_from_8bits_native(
                         stack.write_mem.block.start_address,
                         stack.write_mem.block.source_data,
                         stack.write_mem.block.length);

--- a/test/commands/test_comm_control.cpp
+++ b/test/commands/test_comm_control.cpp
@@ -63,7 +63,7 @@ TEST_F(TestCommControl, TestDiscover)
     uint16_t index = 5;
     expected_response[index++] = 1;
     expected_response[index++] = 0;
-    memcpy_dilate_8bits(&expected_response[index], scrutiny::software_id, SIZEOF_8BITS(scrutiny::software_id));
+    scrutiny::tools::memcpy_dilate_8bits_big_endian(&expected_response[index], scrutiny::software_id, SIZEOF_8BITS(scrutiny::software_id));
     index += SIZEOF_8BITS(scrutiny::software_id);
     expected_response[index++] = static_cast<unsigned char>(DISPLAY_NAME_LENGTH);
     std::memcpy(&expected_response[index], DISPLAY_NAME, DISPLAY_NAME_LENGTH);

--- a/test/commands/test_datalog_control.cpp
+++ b/test/commands/test_datalog_control.cpp
@@ -8,8 +8,6 @@
 
 #include "scrutinytest/scrutinytest.hpp"
 #include <cstring>
-#include <iomanip>
-#include <iostream>
 #include <limits>
 #include <string>
 

--- a/test/commands/test_get_info.cpp
+++ b/test/commands/test_get_info.cpp
@@ -94,7 +94,7 @@ TEST_F(TestGetInfo, TestReadSoftwareId)
     unsigned char expected_response[9 + SIZEOF_8BITS(scrutiny::software_id)] = { 0x81, 2, 0 };
     expected_response[3] = (SIZEOF_8BITS(scrutiny::software_id) >> 8) & 0xFF;
     expected_response[4] = SIZEOF_8BITS(scrutiny::software_id) & 0xFF;
-    memcpy_dilate_8bits(&expected_response[5], scrutiny::software_id, SIZEOF_8BITS(scrutiny::software_id));
+    scrutiny::tools::memcpy_dilate_8bits_big_endian(&expected_response[5], scrutiny::software_id, SIZEOF_8BITS(scrutiny::software_id));
     add_crc(expected_response, 5 + SIZEOF_8BITS(scrutiny::software_id));
 
     scrutiny_handler.receive_data(request_data, sizeof(request_data));

--- a/test/commands/test_memory_control.cpp
+++ b/test/commands/test_memory_control.cpp
@@ -73,13 +73,25 @@ TEST_F(TestMemoryControl, TestReadSingleAddress)
     expected_response[index++] = 0x22;
     expected_response[index++] = 0x33;
 #elif CHAR_BIT == 16
-    // Protocol is big endian
-    expected_response[index++] = 0x11;
-    expected_response[index++] = 0x22;
-    expected_response[index++] = 0x33;
-    expected_response[index++] = 0x44;
-    expected_response[index++] = 0x55;
-    expected_response[index++] = 0x66;
+    // Protocol is big endian, but data bytes endianness is target specific.
+    if (is_little_endian())
+    {
+        expected_response[index++] = 0x22;
+        expected_response[index++] = 0x11;
+        expected_response[index++] = 0x44;
+        expected_response[index++] = 0x33;
+        expected_response[index++] = 0x66;
+        expected_response[index++] = 0x55;
+    }
+    else
+    {
+        expected_response[index++] = 0x11;
+        expected_response[index++] = 0x22;
+        expected_response[index++] = 0x33;
+        expected_response[index++] = 0x44;
+        expected_response[index++] = 0x55;
+        expected_response[index++] = 0x66;
+    }
 #endif
     add_crc(expected_response, sizeof(expected_response) - 4);
 
@@ -456,7 +468,8 @@ TEST_F(TestMemoryControl, TestWriteSingleAddress)
     unsigned char expected_output_buffer[] = { 0x11, 0x22, 0x33, 0x44, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a };
 #elif CHAR_BIT == 16
     unsigned char buffer[] = { 0x0102, 0x0304, 0x0506, 0x0708, 0x090A, 0x0B0C, 0x0D0E, 0x0F10, 0x1011, 0x1213 };
-    unsigned char expected_output_buffer[] = { 0x1122, 0x3344, 0x0506, 0x0708, 0x090A, 0x0B0C, 0x0D0E, 0x0F10, 0x1011, 0x1213 };
+    unsigned char expected_output_buffer_be[] = { 0x1122, 0x3344, 0x0506, 0x0708, 0x090A, 0x0B0C, 0x0D0E, 0x0F10, 0x1011, 0x1213 };
+    unsigned char expected_output_buffer_le[] = { 0x2211, 0x4433, 0x0506, 0x0708, 0x090A, 0x0B0C, 0x0D0E, 0x0F10, 0x1011, 0x1213 };
 #endif
 
     // Building request
@@ -493,7 +506,18 @@ TEST_F(TestMemoryControl, TestWriteSingleAddress)
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
+#if CHAR_BIT == 8
     ASSERT_BUF_EQ(buffer, expected_output_buffer, sizeof(expected_output_buffer));
+#elif CHAR_BIT == 16
+    if (is_little_endian())
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_le, sizeof(expected_output_buffer_le));
+    }
+    else
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
+    }
+#endif    
 }
 
 /*
@@ -502,14 +526,15 @@ TEST_F(TestMemoryControl, TestWriteSingleAddress)
 TEST_F(TestMemoryControl, TestWriteSingleAddressMasked)
 {
 
-    unsigned char data_to_write_8bits[] = { 0xFF, 0xFF, 0x00, 0x00 };
-    unsigned char write_mask_8bits[] = { 0xF0, 0xAA, 0xF0, 0xAA };
+    unsigned char data_to_write_8bits[] = { 0xFF, 0xFF, 0x00, 0x00, 0x55, 0x55 };
+    unsigned char write_mask_8bits[] = { 0xF0, 0xAA, 0xF0, 0xAA, 0xAF, 0x55 };
 #if CHAR_BIT == 8
     unsigned char buffer[] = { 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA };
-    unsigned char expected_output_buffer[] = { 0xFA, 0xAA, 0x0A, 0x00, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA };
+    unsigned char expected_output_buffer[] = { 0xFA, 0xAA, 0x0A, 0x00, 0x05, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA };
 #elif CHAR_BIT == 16
     unsigned char buffer[] = { 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA };
-    unsigned char expected_output_buffer[] = { 0xFAAA, 0x0A00, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA };
+    unsigned char expected_output_buffer_be[] = { 0xFAAA, 0x0A00, 0x05FF, 0xAAAA, 0xAAAA, 0xAAAA };
+    unsigned char expected_output_buffer_le[] = { 0xAAFA, 0x000A, 0xFF05, 0xAAAA, 0xAAAA, 0xAAAA };
 #endif
 
     // Building request
@@ -548,7 +573,18 @@ TEST_F(TestMemoryControl, TestWriteSingleAddressMasked)
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
+#if CHAR_BIT == 8
     ASSERT_BUF_EQ(buffer, expected_output_buffer, sizeof(expected_output_buffer));
+#elif CHAR_BIT == 16
+    if (is_little_endian())
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_le, sizeof(expected_output_buffer_le));
+    }
+    else
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
+    }
+#endif  
 }
 
 /*
@@ -563,7 +599,8 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddress)
 #if CHAR_BIT == 8
     unsigned char expected_output_buffer[] = { 0x11, 0x22, 0x33, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x0a };
 #elif CHAR_BIT == 16
-    unsigned char expected_output_buffer[] = { 0x1122, 0x3344, 0x03, 0xAABB, 0xCCDD, 0xEEFF, 0x07, 0x08, 0x09, 0x0a };
+    unsigned char expected_output_buffer_be[] = { 0x1122, 0x3344, 0x03, 0xAABB, 0xCCDD, 0xEEFF, 0x07, 0x08, 0x09, 0x0a };
+    unsigned char expected_output_buffer_le[] = { 0x2211, 0x4433, 0x03, 0xBBAA, 0xDDCC, 0xFFEE, 0x07, 0x08, 0x09, 0x0a };
 #endif
 
     // Building request
@@ -609,7 +646,18 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddress)
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
+#if CHAR_BIT == 8
     ASSERT_BUF_EQ(buffer, expected_output_buffer, sizeof(expected_output_buffer));
+#elif CHAR_BIT == 16
+    if (is_little_endian())
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_le, sizeof(expected_output_buffer_le));
+    }
+    else
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
+    }
+#endif   
 }
 
 /*
@@ -628,7 +676,8 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddressMasked)
     unsigned int second_write_index = 4;
 #elif CHAR_BIT == 16
     unsigned char buffer[] = { 0x5555, 0x5555, 0x5555, 0x5555, 0x5599 };
-    unsigned char expected_output_buffer[] = { 0x1155, 0x3554, 0x5AFF, 0x5555, 0x0599 };
+    unsigned char expected_output_buffer_be[] = { 0x1155, 0x3554, 0x5AFF, 0x5555, 0x0599 };
+    unsigned char expected_output_buffer_le[] = { 0x5511, 0x5435, 0xFF5A, 0x5555, 0x5509 };
     unsigned int second_write_index = 2;
 #endif
 
@@ -680,7 +729,18 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddressMasked)
     EXPECT_EQ(nread, n_to_read);
 
     ASSERT_BUF_EQ(tx_buffer, expected_response, sizeof(expected_response));
+#if CHAR_BIT == 8
     ASSERT_BUF_EQ(buffer, expected_output_buffer, sizeof(expected_output_buffer));
+#elif CHAR_BIT == 16
+    if (is_little_endian())
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_le, sizeof(expected_output_buffer_le));
+    }
+    else
+    {
+        ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
+    }
+#endif  
 }
 
 TEST_F(TestMemoryControl, TestWriteSingleAddress_InvalidDataLength)

--- a/test/commands/test_memory_control.cpp
+++ b/test/commands/test_memory_control.cpp
@@ -141,17 +141,17 @@ TEST_F(TestMemoryControl, TestReadMultipleAddress)
     index += encode_addr(&expected_response[index], data_buf1);
     expected_response[index++] = (data_size1 >> 8) & 0xFF;
     expected_response[index++] = (data_size1 >> 0) & 0xFF;
-    memcpy_dilate_8bits(&expected_response[index], data_buf1, data_size1);
+    scrutiny::tools::memcpy_dilate_8bits_native(&expected_response[index], data_buf1, data_size1);
     index += data_size1;
     index += encode_addr(&expected_response[index], data_buf2);
     expected_response[index++] = (data_size2 >> 8) & 0xFF;
     expected_response[index++] = (data_size2 >> 0) & 0xFF;
-    memcpy_dilate_8bits(&expected_response[index], data_buf2, data_size2);
+    scrutiny::tools::memcpy_dilate_8bits_native(&expected_response[index], data_buf2, data_size2);
     index += data_size2;
     index += encode_addr(&expected_response[index], data_buf3);
     expected_response[index++] = (data_size3 >> 8) & 0xFF;
     expected_response[index++] = (data_size3 >> 0) & 0xFF;
-    memcpy_dilate_8bits(&expected_response[index], data_buf3, data_size3);
+    scrutiny::tools::memcpy_dilate_8bits_native(&expected_response[index], data_buf3, data_size3);
     index += data_size3;
     add_crc(expected_response, sizeof(expected_response) - 4);
 

--- a/test/commands/test_memory_control.cpp
+++ b/test/commands/test_memory_control.cpp
@@ -517,7 +517,7 @@ TEST_F(TestMemoryControl, TestWriteSingleAddress)
     {
         ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
     }
-#endif    
+#endif
 }
 
 /*
@@ -584,7 +584,7 @@ TEST_F(TestMemoryControl, TestWriteSingleAddressMasked)
     {
         ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
     }
-#endif  
+#endif
 }
 
 /*
@@ -657,7 +657,7 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddress)
     {
         ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
     }
-#endif   
+#endif
 }
 
 /*
@@ -740,7 +740,7 @@ TEST_F(TestMemoryControl, TestWriteMultipleAddressMasked)
     {
         ASSERT_BUF_EQ(buffer, expected_output_buffer_be, sizeof(expected_output_buffer_be));
     }
-#endif  
+#endif
 }
 
 TEST_F(TestMemoryControl, TestWriteSingleAddress_InvalidDataLength)

--- a/test/datalogging/raw_format_parser.cpp
+++ b/test/datalogging/raw_format_parser.cpp
@@ -142,18 +142,25 @@ void RawFormatParser::parse(uint32_t entry_count)
                 return;
             }
 
-            if (m_config->items_to_log[i].type == scrutiny::datalogging::LoggableType::Memory)
+            if (m_config->items_to_log[j].type == scrutiny::datalogging::LoggableType::Memory)
             {
                 scrutiny::tools::memcpy_compress_from_8bits_native(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
             }
-            else if (m_config->items_to_log[i].type == scrutiny::datalogging::LoggableType::Rpv)
+            else if (m_config->items_to_log[j].type == scrutiny::datalogging::LoggableType::Rpv)
             {
+                // scrutiny::tools::memcpy_compress_from_8bits_native(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
                 scrutiny::tools::memcpy_compress_from_8bits_big_endian(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
             }
-            else if ( m_config->items_to_log[i].type == scrutiny::datalogging::LoggableType::Time)
+            else if (m_config->items_to_log[j].type == scrutiny::datalogging::LoggableType::Time)
             {
+                // scrutiny::tools::memcpy_compress_from_8bits_native(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
                 uint32_t const v = scrutiny::codecs::decode_32_bits_big_endian_8bits(&m_buffer[src_cursor]);
                 scrutiny::codecs::encode_32_bits_big_endian_char(v, dst_ptr);
+            }
+            else
+            {
+                volatile int x = 1;
+                (void)x;
             }
 
             // The parser reads back what has been written in the output buffer by the reader.

--- a/test/datalogging/raw_format_parser.cpp
+++ b/test/datalogging/raw_format_parser.cpp
@@ -144,7 +144,7 @@ void RawFormatParser::parse(uint32_t entry_count)
 
             // The parser reads back what has been written in the output buffer by the reader.
             // the output buffer is dilated. Compress back to use full char
-            scrutiny::tools::memcpy_compress_from_8bits(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
+            scrutiny::tools::memcpy_compress_from_8bits_native(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
             src_cursor += elem_size_char * (CHAR_BIT / 8);
         }
     }

--- a/test/datalogging/raw_format_parser.cpp
+++ b/test/datalogging/raw_format_parser.cpp
@@ -142,9 +142,22 @@ void RawFormatParser::parse(uint32_t entry_count)
                 return;
             }
 
+            if (m_config->items_to_log[i].type == scrutiny::datalogging::LoggableType::Memory)
+            {
+                scrutiny::tools::memcpy_compress_from_8bits_native(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
+            }
+            else if (m_config->items_to_log[i].type == scrutiny::datalogging::LoggableType::Rpv)
+            {
+                scrutiny::tools::memcpy_compress_from_8bits_big_endian(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
+            }
+            else if ( m_config->items_to_log[i].type == scrutiny::datalogging::LoggableType::Time)
+            {
+                uint32_t const v = scrutiny::codecs::decode_32_bits_big_endian_8bits(&m_buffer[src_cursor]);
+                scrutiny::codecs::encode_32_bits_big_endian_char(v, dst_ptr);
+            }
+
             // The parser reads back what has been written in the output buffer by the reader.
             // the output buffer is dilated. Compress back to use full char
-            scrutiny::tools::memcpy_compress_from_8bits_native(dst_ptr, &m_buffer[src_cursor], elem_size_char * (CHAR_BIT / 8));
             src_cursor += elem_size_char * (CHAR_BIT / 8);
         }
     }

--- a/test/datalogging/raw_format_parser.cpp
+++ b/test/datalogging/raw_format_parser.cpp
@@ -159,8 +159,8 @@ void RawFormatParser::parse(uint32_t entry_count)
             }
             else
             {
-                volatile int x = 1;
-                (void)x;
+                m_error = true;
+                return;
             }
 
             // The parser reads back what has been written in the output buffer by the reader.

--- a/test/datalogging/test_raw_encoder.cpp
+++ b/test/datalogging/test_raw_encoder.cpp
@@ -137,22 +137,22 @@ TEST_F(TestRawEncoder, BasicEncoding)
     var2 = 0x1111;
     expected_time = 0;
 
-    memcpy_dilate_8bits(&compare_buf[0], &var1, 4);
-    memcpy_dilate_8bits(&compare_buf[4], &var2, 4);
+    scrutiny::tools::memcpy_dilate_8bits_native(&compare_buf[0], &var1, 4);
+    scrutiny::tools::memcpy_dilate_8bits_native(&compare_buf[4], &var2, 4);
     scrutiny::codecs::encode_32_bits_big_endian_8bits(expected_time, &compare_buf[8]);
 
     var1 = 2.0f;
     var2 = 0x2222;
     expected_time = 100;
-    memcpy_dilate_8bits(&compare_buf[12], &var1, 4);
-    memcpy_dilate_8bits(&compare_buf[16], &var2, 4);
+    scrutiny::tools::memcpy_dilate_8bits_native(&compare_buf[12], &var1, 4);
+    scrutiny::tools::memcpy_dilate_8bits_native(&compare_buf[16], &var2, 4);
     scrutiny::codecs::encode_32_bits_big_endian_8bits(expected_time, &compare_buf[20]);
 
     var1 = 3.0f;
     var2 = 0x3333;
     expected_time = 200u;
-    memcpy_dilate_8bits(&compare_buf[24], &var1, 4);
-    memcpy_dilate_8bits(&compare_buf[28], &var2, 4);
+    scrutiny::tools::memcpy_dilate_8bits_native(&compare_buf[24], &var1, 4);
+    scrutiny::tools::memcpy_dilate_8bits_native(&compare_buf[28], &var2, 4);
     scrutiny::codecs::encode_32_bits_big_endian_8bits(expected_time, &compare_buf[32]);
 
     unsigned char const chunk_size = sizeof(dst_buffer);

--- a/test/scrutiny_test.hpp
+++ b/test/scrutiny_test.hpp
@@ -46,9 +46,9 @@ class ScrutinyTest : public scrutinytest::TestCase
     {
         uint32_t x = 0x12345678;
 #if CHAR_BIT == 8
-        return *reinterpret_cast<unsigned char *>(&x) == 0x12;
+        return *reinterpret_cast<unsigned char *>(&x) == 0x78;
 #elif CHAR_BIT == 16
-        return *reinterpret_cast<unsigned char *>(&x) == 0x1234;
+        return *reinterpret_cast<unsigned char *>(&x) == 0x5678;
 #endif
     }
 

--- a/test/scrutiny_test.hpp
+++ b/test/scrutiny_test.hpp
@@ -42,15 +42,32 @@
 class ScrutinyTest : public scrutinytest::TestCase
 {
   protected:
+    inline bool is_little_endian() const
+    {
+        uint32_t x = 0x12345678;
+        return *reinterpret_cast<unsigned char *>(&x) == 0x1234;
+    }
+
     inline void memcpy_dilate_8bits(void *const dst, void const *const src, size_t const nb_8bits)
     {
 #if CHAR_BIT == 8
         memcpy(dst, src, nb_8bits);
 #elif CHAR_BIT == 16
-        for (size_t i = 0; i < (nb_8bits >> 1); i++)
+        if (is_little_endian())
         {
-            static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
-            static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
+            for (size_t i = 0; i < (nb_8bits >> 1); i++)
+            {
+                static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
+                static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < (nb_8bits >> 1); i++)
+            {
+                static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
+                static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
+            }
         }
 #endif
     }

--- a/test/scrutiny_test.hpp
+++ b/test/scrutiny_test.hpp
@@ -45,7 +45,11 @@ class ScrutinyTest : public scrutinytest::TestCase
     inline bool is_little_endian() const
     {
         uint32_t x = 0x12345678;
+#if CHAR_BIT == 8
+        return *reinterpret_cast<unsigned char *>(&x) == 0x12;
+#elif CHAR_BIT == 16
         return *reinterpret_cast<unsigned char *>(&x) == 0x1234;
+#endif
     }
 
     inline void memcpy_dilate_8bits(void *const dst, void const *const src, size_t const nb_8bits)

--- a/test/scrutiny_test.hpp
+++ b/test/scrutiny_test.hpp
@@ -52,30 +52,6 @@ class ScrutinyTest : public scrutinytest::TestCase
 #endif
     }
 
-    inline void memcpy_dilate_8bits(void *const dst, void const *const src, size_t const nb_8bits)
-    {
-#if CHAR_BIT == 8
-        memcpy(dst, src, nb_8bits);
-#elif CHAR_BIT == 16
-        if (is_little_endian())
-        {
-            for (size_t i = 0; i < (nb_8bits >> 1); i++)
-            {
-                static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
-                static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
-            }
-        }
-        else
-        {
-            for (size_t i = 0; i < (nb_8bits >> 1); i++)
-            {
-                static_cast<unsigned char *>(dst)[2 * i] = (static_cast<unsigned char const *>(src)[i] >> 8) & 0xFF;
-                static_cast<unsigned char *>(dst)[2 * i + 1] = (static_cast<unsigned char const *>(src)[i] & 0xFF);
-            }
-        }
-#endif
-    }
-
     inline std::vector<unsigned char> make_payload_1(unsigned char v0)
     {
         std::vector<unsigned char> o;

--- a/test/test_codecs.cpp
+++ b/test/test_codecs.cpp
@@ -126,24 +126,29 @@ TEST_F(TestCodecs, EncodeBigEndian_char)
 
 #elif CHAR_BIT == 16
 
-    unsigned char outbuffer[4];
+    unsigned char outbuffer[8];
+    unsigned char outbuffer_dilated[8];
 
-    unsigned char buffer16[1] = { 0x1234 };
+    unsigned char buffer16_dilated[2] = { 0x12, 0x34 };
     scrutiny::codecs::encode_16_bits_big_endian_char((uint16_t)0x1234u, outbuffer);
-    EXPECT_BUF_EQ(outbuffer, buffer16, sizeof(buffer16));
+    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 2);
+    EXPECT_BUF_EQ(outbuffer_dilated, buffer16_dilated, 2);
 
-    unsigned char buffer32[2] = { 0x1234, 0x5678 };
+    unsigned char buffer32_dilated[4] = { 0x12, 0x34, 0x56, 0x78 }; // Dilation to handle databits endianess within a single char
     scrutiny::codecs::encode_32_bits_big_endian_char((uint32_t)0x12345678u, outbuffer);
-    EXPECT_BUF_EQ(outbuffer, buffer32, sizeof(buffer32));
+    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 4);
+    EXPECT_BUF_EQ(outbuffer_dilated, buffer32_dilated, 4);
 
-    unsigned char buffer_float[2] = { 0x4049, 0x0fda };
+    unsigned char buffer_float_dilated[2] = { 0x40, 0x49, 0x0f, 0xda };
     scrutiny::codecs::encode_float_big_endian_char(3.1415926f, outbuffer);
-    EXPECT_BUF_EQ(outbuffer, buffer_float, sizeof(buffer_float));
+    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 4);
+    EXPECT_BUF_EQ(outbuffer_dilated, buffer_float_dilated, 4);
 
 #if SCRUTINY_SUPPORT_64BITS
-    unsigned char buffer64[4] = { 0x1234, 0x5678, 0x9abc, 0xdef0 };
+    unsigned char buffer64_dilated[8] = { 0x1234, 0x5678, 0x9abc, 0xdef0 };
     scrutiny::codecs::encode_64_bits_big_endian_char((uint64_t)0x123456789abcdef0u, outbuffer);
-    EXPECT_BUF_EQ(outbuffer, buffer64, sizeof(buffer64));
+    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 8);
+    EXPECT_BUF_EQ(outbuffer_dilated, buffer64_dilated, 8);
 #endif
 
 #endif

--- a/test/test_codecs.cpp
+++ b/test/test_codecs.cpp
@@ -126,29 +126,24 @@ TEST_F(TestCodecs, EncodeBigEndian_char)
 
 #elif CHAR_BIT == 16
 
-    unsigned char outbuffer[8];
-    unsigned char outbuffer_dilated[8];
+    unsigned char outbuffer[4];
 
-    unsigned char buffer16_dilated[2] = { 0x12, 0x34 };
+    unsigned char buffer16[1] = { 0x1234 };
     scrutiny::codecs::encode_16_bits_big_endian_char((uint16_t)0x1234u, outbuffer);
-    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 2);
-    EXPECT_BUF_EQ(outbuffer_dilated, buffer16_dilated, 2);
+    EXPECT_BUF_EQ(outbuffer, buffer16, sizeof(buffer16));
 
-    unsigned char buffer32_dilated[4] = { 0x12, 0x34, 0x56, 0x78 }; // Dilation to handle databits endianess within a single char
+    unsigned char buffer32[2] = { 0x1234, 0x5678 };
     scrutiny::codecs::encode_32_bits_big_endian_char((uint32_t)0x12345678u, outbuffer);
-    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 4);
-    EXPECT_BUF_EQ(outbuffer_dilated, buffer32_dilated, 4);
+    EXPECT_BUF_EQ(outbuffer, buffer32, sizeof(buffer32));
 
-    unsigned char buffer_float_dilated[2] = { 0x40, 0x49, 0x0f, 0xda };
+    unsigned char buffer_float[2] = { 0x4049, 0x0fda };
     scrutiny::codecs::encode_float_big_endian_char(3.1415926f, outbuffer);
-    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 4);
-    EXPECT_BUF_EQ(outbuffer_dilated, buffer_float_dilated, 4);
+    EXPECT_BUF_EQ(outbuffer, buffer_float, sizeof(buffer_float));
 
 #if SCRUTINY_SUPPORT_64BITS
-    unsigned char buffer64_dilated[8] = { 0x1234, 0x5678, 0x9abc, 0xdef0 };
+    unsigned char buffer64[4] = { 0x1234, 0x5678, 0x9abc, 0xdef0 };
     scrutiny::codecs::encode_64_bits_big_endian_char((uint64_t)0x123456789abcdef0u, outbuffer);
-    scrutiny::tools::memcpy_dilate_8bits_big_endian(outbuffer_dilated, outbuffer, 8);
-    EXPECT_BUF_EQ(outbuffer_dilated, buffer64_dilated, 8);
+    EXPECT_BUF_EQ(outbuffer, buffer64, sizeof(buffer64));
 #endif
 
 #endif


### PR DESCRIPTION
Review endianness handling everywhere so the following action expose a standardized endianness to the server. 
- memory read
- memory write 
- datalogging buffer
- Software ID

Rules are:
1. Memory content are bytes per bytes. 16 bits byte follow the platform endianness
2. RPV are encoded in big endian on a 8bits basis.
3. Time in datalogging are encoded in big endian on a 8bits basis
4. Software ID follows the platform endianness
