### PR TITLE
Bugfix: Special regions boundary check + Varbit span in datalog configure

### DIFF
--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -1315,7 +1315,7 @@ namespace scrutiny
         }
 
         uintptr_t const block_start = reinterpret_cast<uintptr_t>(addr_start);
-        uintptr_t const block_end = block_start + length;
+        uintptr_t const block_end = block_start + length - 1;
 
         for (unsigned int i = 0; i < m_config.forbidden_ranges_count(); i++)
         {
@@ -1337,7 +1337,7 @@ namespace scrutiny
         }
 
         uintptr_t const block_start = reinterpret_cast<uintptr_t>(addr_start);
-        uintptr_t const block_end = block_start + length;
+        uintptr_t const block_end = block_start + length - 1;
         for (unsigned int i = 0; i < m_config.readonly_ranges_count(); i++)
         {
             AddressRange const &range = m_config.readonly_ranges()[i];
@@ -1481,7 +1481,7 @@ namespace scrutiny
                 {
                     if (touches_forbidden_region(
                             config->trigger.operands[i].data.var.addr,
-                            tools::get_type_size_8bits(config->trigger.operands[i].data.var.datatype)))
+                            tools::get_type_size_char(config->trigger.operands[i].data.var.datatype)))
                     {
                         code = protocol::ResponseCode::Forbidden;
                         break;
@@ -1489,9 +1489,10 @@ namespace scrutiny
                 }
                 else if (config->trigger.operands[i].type == datalogging::OperandType::VarBit)
                 {
+                    // The library needs to access the full type, even if bitsize is small.
                     if (touches_forbidden_region(
                             config->trigger.operands[i].data.varbit.addr,
-                            config->trigger.operands[i].data.varbit.bitoffset + config->trigger.operands[i].data.varbit.bitsize))
+                            tools::get_type_size_char(config->trigger.operands[i].data.varbit.datatype)))
                     {
                         code = protocol::ResponseCode::Forbidden;
                         break;

--- a/test/commands/test_datalog_control.cpp
+++ b/test/commands/test_datalog_control.cpp
@@ -538,6 +538,26 @@ TEST_F(TestDatalogControl, TestConfigureOperandVarBitInForbiddenRegion)
     test_configure(loop_id, 0, refconfig, protocol::ResponseCode::Forbidden);
 }
 
+TEST_F(TestDatalogControl, TestConfigureOperandVarBitAlmostInForbiddenRegion)
+{
+    unsigned char forbidden_buffer[8];
+    AddressRange forbidden_ranges[1];
+    forbidden_ranges[0] = tools::make_address_range(&forbidden_buffer[4], 2); // Protect indices 4,5
+    config.set_forbidden_address_range(forbidden_ranges, sizeof(forbidden_ranges) / sizeof(forbidden_ranges[0]));
+    scrutiny_handler.init(&config);
+    scrutiny_handler.comm()->connect();
+
+    SCRUTINY_CONSTEXPR uint_least8_t loop_id = 1;
+    datalogging::Configuration refconfig = get_valid_reference_configuration();
+    refconfig.trigger.operands[1].type = datalogging::OperandType::VarBit;
+    refconfig.trigger.operands[1].data.varbit.addr = &forbidden_buffer[2];
+    refconfig.trigger.operands[1].data.varbit.datatype = VariableType::uint16;
+    refconfig.trigger.operands[1].data.varbit.bitoffset = 0;
+    refconfig.trigger.operands[1].data.varbit.bitsize = 8;
+
+    test_configure(loop_id, 0, refconfig, protocol::ResponseCode::OK); // We don't overflow
+}
+
 TEST_F(TestDatalogControl, TestConfigureUnknownCondition)
 {
     SCRUTINY_CONSTEXPR uint_least8_t loop_id = 1;

--- a/test/commands/test_memory_control.cpp
+++ b/test/commands/test_memory_control.cpp
@@ -332,7 +332,7 @@ TEST_F(TestMemoryControl, TestReadForbiddenAddress)
     unsigned char buf[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
     // indices [6,7,8,9] are forbidden
     uintptr_t start = reinterpret_cast<uintptr_t>(buf) + 6;
-    uintptr_t end = start + 4;
+    uintptr_t end = start + 4 - 1;
     scrutiny::AddressRange forbidden_ranges[] = { scrutiny::tools::make_address_range(start, end) };
     config.set_forbidden_address_range(forbidden_ranges, sizeof(forbidden_ranges) / sizeof(scrutiny::AddressRange));
 
@@ -360,7 +360,7 @@ TEST_F(TestMemoryControl, TestReadForbiddenAddress)
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
         scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
-        if (i < 2 || i > 10) // Sliding window is completely out of forbidden region
+        if (i < 3 || i > 9) // Sliding window is completely out of forbidden region
         {
             ASSERT_IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, ok) << "[i=" << static_cast<uint32_t>(i) << "]";
         }
@@ -383,7 +383,7 @@ TEST_F(TestMemoryControl, TestReadForbiddenAddressContainment)
     unsigned char buf[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
     // indices [6,7,8,9] are forbidden
     uintptr_t start = reinterpret_cast<uintptr_t>(buf) + 6;
-    uintptr_t end = start + 4;
+    uintptr_t end = start + 4 - 1;
     scrutiny::AddressRange forbidden_ranges[] = { scrutiny::tools::make_address_range(start, end) };
     config.set_forbidden_address_range(forbidden_ranges, sizeof(forbidden_ranges) / sizeof(scrutiny::AddressRange));
 
@@ -426,7 +426,7 @@ TEST_F(TestMemoryControl, TestReadReadonlyAddress)
 
     // indices [6,7,8,9] are readonly
     uintptr_t start = reinterpret_cast<uintptr_t>(buf) + 6;
-    uintptr_t end = start + 4;
+    uintptr_t end = start + 4 - 1;
     scrutiny::AddressRange readonly_range[] = { scrutiny::tools::make_address_range(start, end) };
     config.set_readonly_address_range(readonly_range, sizeof(readonly_range) / sizeof(scrutiny::AddressRange));
 
@@ -866,7 +866,7 @@ TEST_F(TestMemoryControl, TestWriteForbiddenAddress)
     unsigned char buf[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
     // indices [6,7,8,9] are forbidden
     uintptr_t start = reinterpret_cast<uintptr_t>(buf) + 6;
-    uintptr_t end = start + 4;
+    uintptr_t end = start + 4 - 1;
     scrutiny::AddressRange forbidden_ranges[] = { scrutiny::tools::make_address_range(start, end) };
     config.set_forbidden_address_range(forbidden_ranges, sizeof(forbidden_ranges) / sizeof(scrutiny::AddressRange));
 
@@ -894,7 +894,7 @@ TEST_F(TestMemoryControl, TestWriteForbiddenAddress)
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
         scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
-        if (i < 2 || i > 10) // Sliding window is completely out of forbidden region
+        if (i < 3 || i > 9) // Sliding window is completely out of forbidden region
         {
             ASSERT_IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, ok) << "[i=" << static_cast<uint32_t>(i) << "]";
         }
@@ -921,7 +921,7 @@ TEST_F(TestMemoryControl, TestWriteReadOnlyAddress)
     unsigned char buf[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
     // indices [6,7,8,9] are forbidden
     uintptr_t start = reinterpret_cast<uintptr_t>(buf) + 6;
-    uintptr_t end = start + 4;
+    uintptr_t end = start + 4 - 1;
     scrutiny::AddressRange readonly_ranges[] = { scrutiny::tools::make_address_range(start, end) };
     config.set_readonly_address_range(readonly_ranges, sizeof(readonly_ranges) / sizeof(scrutiny::AddressRange));
 
@@ -949,7 +949,7 @@ TEST_F(TestMemoryControl, TestWriteReadOnlyAddress)
         ASSERT_LT(n_to_read, sizeof(tx_buffer));
         scrutiny_handler.pop_data(tx_buffer, n_to_read);
 
-        if (i < 2 || i > 10) // Sliding window is completely out of readonly region
+        if (i < 3 || i > 9) // Sliding window is completely out of readonly region
         {
             ASSERT_IS_PROTOCOL_RESPONSE(tx_buffer, cmd, subfn, ok) << "[i=" << static_cast<uint32_t>(i) << "]";
         }
@@ -971,7 +971,7 @@ TEST_F(TestMemoryControl, TestWriteReadOnlyAddressRegionContained)
     unsigned char buf[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
     // indices [6,7,8,9] are forbidden
     uintptr_t start = reinterpret_cast<uintptr_t>(buf) + 6;
-    uintptr_t end = start + 4;
+    uintptr_t end = start + 4 - 1;
     scrutiny::AddressRange readonly_ranges[] = { scrutiny::tools::make_address_range(start, end) };
     config.set_readonly_address_range(readonly_ranges, sizeof(readonly_ranges) / sizeof(scrutiny::AddressRange));
 


### PR DESCRIPTION
- ``touches_forbidden_region`` and ``touches_readonly_region`` would pick an extra byte at the end of the regions
- Configuring a varbit for the datalogger would pass a bitsize in a bytesize check