### PR TITLE
Reduce stack usage

### DIFF
--- a/lib/inc/datalogging/scrutiny_datalogger.hpp
+++ b/lib/inc/datalogging/scrutiny_datalogger.hpp
@@ -174,6 +174,15 @@ namespace scrutiny
                 trigger::ActiveCondition active_condition;   // The active condition object.
                 trigger::ConditionSharedData condition_data; // Persistent data across trigger evaluation
             } m_trigger;                                     // Data related to the graph trigger
+
+            union
+            {
+                struct
+                {
+                    AnyType opvals[MAX_OPERANDS];
+                    VariableType::eVariableType optypes[MAX_OPERANDS];
+                } check_trigger;
+            } m_temp_data;
         };
     } // namespace datalogging
 } // namespace scrutiny

--- a/lib/inc/datalogging/scrutiny_datalogger.hpp
+++ b/lib/inc/datalogging/scrutiny_datalogger.hpp
@@ -182,7 +182,7 @@ namespace scrutiny
                     AnyType opvals[MAX_OPERANDS];
                     VariableType::eVariableType optypes[MAX_OPERANDS];
                 } check_trigger;
-            } m_temp_data;
+            } m_stack_data; // Move some data out of the stack.
         };
     } // namespace datalogging
 } // namespace scrutiny

--- a/lib/inc/protocol/scrutiny_codec_v1_0.hpp
+++ b/lib/inc/protocol/scrutiny_codec_v1_0.hpp
@@ -155,9 +155,9 @@ namespace scrutiny
             unsigned char *m_buffer;
             uint16_t m_bytes_read;
             uint16_t m_request_len;
+            MainHandler const *m_main_handler;
             bool m_finished;
             bool m_invalid;
-            MainHandler const *m_main_handler;
         };
 
         namespace ResponseData

--- a/lib/inc/scrutiny_main_handler.hpp
+++ b/lib/inc/scrutiny_main_handler.hpp
@@ -105,7 +105,13 @@ namespace scrutiny
         /// @param src  Source buffer
         /// @param size Size of data to transfer
         /// @return true on success, false on failure
-        bool read_memory(void *const dst, void const *const src, uint32_t const size) const;
+        inline bool read_memory(void *const dst, void const *const src, uint32_t const size) const
+        {
+            // We keep a wrapper over memcpy to check for permission.
+            // Right now, oermissions are enforced outisde and it's enough
+            memcpy(dst, src, size);
+            return true;
+        }
 
         /// @brief Reads a variable from a memory location. Ensure the respect of forbidden regions and will not make unaligned memory access
         /// @param addr Address at which the variable is stored

--- a/lib/src/datalogging/scrutiny_datalogger.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger.cpp
@@ -402,19 +402,19 @@ namespace scrutiny
                     if (fetch_operand(
                             m_main_handler,
                             &m_config.trigger.operands[i],
-                            &m_temp_data.check_trigger.opvals[i],
-                            &m_temp_data.check_trigger.optypes[i],
+                            &m_stack_data.check_trigger.opvals[i],
+                            &m_stack_data.check_trigger.optypes[i],
                             SCRUTINY_NULL) == false)
                     {
                         return false;
                     }
-                    convert_to_compare_type(&m_temp_data.check_trigger.optypes[i], &m_temp_data.check_trigger.opvals[i]);
+                    convert_to_compare_type(&m_stack_data.check_trigger.optypes[i], &m_stack_data.check_trigger.opvals[i]);
                 }
 
-                bool condition_result = m_trigger.active_condition.eval_fn(
+                bool const condition_result = m_trigger.active_condition.eval_fn(
                     &m_trigger.condition_data,
-                    reinterpret_cast<VariableTypeCompare::eVariableTypeCompare *>(m_temp_data.check_trigger.optypes),
-                    reinterpret_cast<AnyTypeCompare *>(m_temp_data.check_trigger.opvals));
+                    reinterpret_cast<VariableTypeCompare::eVariableTypeCompare *>(m_stack_data.check_trigger.optypes),
+                    reinterpret_cast<AnyTypeCompare *>(m_stack_data.check_trigger.opvals));
 
                 if (condition_result)
                 {

--- a/lib/src/datalogging/scrutiny_datalogger.cpp
+++ b/lib/src/datalogging/scrutiny_datalogger.cpp
@@ -381,8 +381,6 @@ namespace scrutiny
             }
 
             bool outval = false;
-            AnyType opvals[MAX_OPERANDS];
-            VariableType::eVariableType optypes[MAX_OPERANDS];
             const unsigned int nb_operand = m_trigger.active_condition.operand_count;
 
             if (nb_operand > MAX_OPERANDS)
@@ -401,17 +399,22 @@ namespace scrutiny
 
                 for (unsigned int i = 0; i < nb_operand; i++)
                 {
-                    if (fetch_operand(m_main_handler, &m_config.trigger.operands[i], &opvals[i], &optypes[i], SCRUTINY_NULL) == false)
+                    if (fetch_operand(
+                            m_main_handler,
+                            &m_config.trigger.operands[i],
+                            &m_temp_data.check_trigger.opvals[i],
+                            &m_temp_data.check_trigger.optypes[i],
+                            SCRUTINY_NULL) == false)
                     {
                         return false;
                     }
-                    convert_to_compare_type(&optypes[i], &opvals[i]);
+                    convert_to_compare_type(&m_temp_data.check_trigger.optypes[i], &m_temp_data.check_trigger.opvals[i]);
                 }
 
                 bool condition_result = m_trigger.active_condition.eval_fn(
                     &m_trigger.condition_data,
-                    reinterpret_cast<VariableTypeCompare::eVariableTypeCompare *>(optypes),
-                    reinterpret_cast<AnyTypeCompare *>(opvals));
+                    reinterpret_cast<VariableTypeCompare::eVariableTypeCompare *>(m_temp_data.check_trigger.optypes),
+                    reinterpret_cast<AnyTypeCompare *>(m_temp_data.check_trigger.opvals));
 
                 if (condition_result)
                 {

--- a/lib/src/datalogging/scrutiny_datalogging.cpp
+++ b/lib/src/datalogging/scrutiny_datalogging.cpp
@@ -133,8 +133,8 @@ namespace scrutiny
             else if (operand->type == OperandType::VarBit)
             {
                 success = main_handler->fetch_variable_bitfield(
-                    operand->data.var.addr,
-                    tools::get_var_type_type(operand->data.var.datatype),
+                    operand->data.varbit.addr,
+                    tools::get_var_type_type(operand->data.varbit.datatype),
                     operand->data.varbit.bitoffset,
                     operand->data.varbit.bitsize,
                     val,

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -128,12 +128,6 @@ namespace scrutiny
 
 #if SCRUTINY_ENABLE_DATALOGGING
 
-    bool MainHandler::read_memory(void *dst, void const *const src, uint32_t const size) const
-    {
-        memcpy(dst, src, size);
-        return true;
-    }
-
     bool MainHandler::fetch_variable(void const *const addr, VariableType::eVariableType const variable_type, AnyType *const val) const
     {
         uint_least8_t typesize_char = tools::get_type_size_8bits(variable_type) / (CHAR_BIT / 8);

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -217,8 +217,8 @@ namespace scrutiny
 #if CHAR_BIT == 8
                     if (output_type_size == VariableTypeSize::_8)
                     {
-                        mask.uint8 =
-                            (bitsize < 8u) ? static_cast<uint_fast8_t>((static_cast<uint8_t>(1) << bitsize) - 1u) : static_cast<uint_fast8_t>(static_cast<uint8_t>(0xFF));
+                        mask.uint8 = (bitsize < 8u) ? static_cast<uint_fast8_t>((static_cast<uint8_t>(1) << bitsize) - 1u)
+                                                    : static_cast<uint_fast8_t>(static_cast<uint8_t>(0xFF));
                         val->uint8 &= mask.uint8;
                         if (var_tt == VariableTypeType::_sint)
                         {
@@ -245,7 +245,8 @@ namespace scrutiny
                     }
                     else if (output_type_size == VariableTypeSize::_32)
                     {
-                        mask.uint32 = (bitsize < 32u) ? static_cast<uint_fast32_t>((static_cast<uint32_t>(1) << bitsize) - 1u) : static_cast<uint32_t>(0xFFFFFFFF);
+                        mask.uint32 = (bitsize < 32u) ? static_cast<uint_fast32_t>((static_cast<uint32_t>(1) << bitsize) - 1u)
+                                                      : static_cast<uint32_t>(0xFFFFFFFF);
                         val->uint32 &= mask.uint32;
                         if (var_tt == VariableTypeType::_sint)
                         {
@@ -258,7 +259,8 @@ namespace scrutiny
 #if SCRUTINY_SUPPORT_64BITS
                     else if (output_type_size == VariableTypeSize::_64)
                     {
-                        mask.uint64 = (bitsize < 64u) ? static_cast<uint_fast64_t>((static_cast<uint64_t>(1) << bitsize) - 1u) : static_cast<uint64_t>(0xFFFFFFFFFFFFFFFF);
+                        mask.uint64 = (bitsize < 64u) ? static_cast<uint_fast64_t>((static_cast<uint64_t>(1) << bitsize) - 1u)
+                                                      : static_cast<uint64_t>(0xFFFFFFFFFFFFFFFF);
                         val->uint64 &= mask.uint64;
                         if (var_tt == VariableTypeType::_sint)
                         {
@@ -1007,7 +1009,7 @@ namespace scrutiny
         protocol::ResponseCode::eResponseCode code = protocol::ResponseCode::FailureToProceed;
 
         // Make sure the compiler optimize stack space. Because it may well not (don't trust this guy.)
-        union
+        struct
         {
             struct
             {

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -130,11 +130,6 @@ namespace scrutiny
 
     bool MainHandler::read_memory(void *dst, void const *const src, uint32_t const size) const
     {
-        if (touches_forbidden_region(src, size))
-        {
-            return false;
-        }
-
         memcpy(dst, src, size);
         return true;
     }
@@ -170,13 +165,11 @@ namespace scrutiny
         VariableTypeSize::eVariableTypeSize const output_type_size = tools::get_required_type_size_8bits(output_required_size);
         VariableType::eVariableType const fetch_variable_type = tools::make_type(VariableTypeType::_uint, fetch_type_size);
         VariableType::eVariableType const output_variable_type = tools::make_type(var_tt, output_type_size);
-        uint_least8_t const typesize_char = tools::get_type_size_8bits(fetch_variable_type) / (CHAR_BIT / 8);
 
-        if (touches_forbidden_region(addr, typesize_char))
-        {
-            success = false;
-        }
-        else if (bitsize == 0)
+        // We do not check for forbidden regions here. This function is only used by the datalogger.
+        // The Main Handler is expected to validate the datalogger config.
+
+        if (bitsize == 0)
         {
             success = false;
         }

--- a/lib/src/scrutiny_main_handler.cpp
+++ b/lib/src/scrutiny_main_handler.cpp
@@ -1009,7 +1009,7 @@ namespace scrutiny
         protocol::ResponseCode::eResponseCode code = protocol::ResponseCode::FailureToProceed;
 
         // Make sure the compiler optimize stack space. Because it may well not (don't trust this guy.)
-        struct
+        union
         {
             struct
             {

--- a/test/commands/test_datalog_control.cpp
+++ b/test/commands/test_datalog_control.cpp
@@ -500,6 +500,23 @@ TEST_F(TestDatalogControl, TestConfigureOperandBadRPV)
     test_configure(loop_id, 0, refconfig, protocol::ResponseCode::FailureToProceed);
 }
 
+TEST_F(TestDatalogControl, TestConfigureSignalInForbiddenRegion)
+{
+    uint32_t forbidden_var;
+    AddressRange forbidden_ranges[1];
+    forbidden_ranges[0] = tools::make_address_range(&forbidden_var, sizeof(forbidden_var));
+    config.set_forbidden_address_range(forbidden_ranges, sizeof(forbidden_ranges) / sizeof(forbidden_ranges[0]));
+    scrutiny_handler.init(&config);
+    scrutiny_handler.comm()->connect();
+
+    SCRUTINY_CONSTEXPR uint_least8_t loop_id = 1;
+    datalogging::Configuration refconfig = get_valid_reference_configuration();
+    refconfig.items_to_log[1].data.memory.address = &forbidden_var;
+    refconfig.items_to_log[1].data.memory.size = sizeof(forbidden_var);
+
+    test_configure(loop_id, 0, refconfig, protocol::ResponseCode::Forbidden);
+}
+
 TEST_F(TestDatalogControl, TestConfigureOperandVarInForbiddenRegion)
 {
     uint32_t forbidden_var;

--- a/test/datalogging/test_fetch_operands.cpp
+++ b/test/datalogging/test_fetch_operands.cpp
@@ -185,20 +185,6 @@ TEST_F(TestFetchOperands, TestBadOperandType)
     EXPECT_FALSE(success);
 }
 
-TEST_F(TestFetchOperands, TestFetchForbiddenMemory)
-{
-    scrutiny::AnyType val;
-    scrutiny::VariableType::eVariableType vartype = scrutiny::VariableType::unknown;
-
-    Operand operand;
-    operand.type = OperandType::Var;
-    operand.data.var.addr = forbidden_buffer;
-    operand.data.var.datatype = scrutiny::VariableType::uint16;
-
-    bool success = fetch_operand(&scrutiny_handler, &operand, &val, &vartype, SCRUTINY_NULL);
-    EXPECT_FALSE(success);
-}
-
 TEST_F(TestFetchOperands, TestFetchInexistandRPV)
 {
     scrutiny::AnyType val;

--- a/test/test_variable_fetching.cpp
+++ b/test/test_variable_fetching.cpp
@@ -100,23 +100,6 @@ TEST_F(TestVariableFetching, RandomFetch)
     EXPECT_TRUE(success);
 }
 
-TEST_F(TestVariableFetching, NoAccess)
-{
-    scrutiny::AnyType outval;
-    bool success;
-    success = scrutiny_handler.fetch_variable(forbidden_buffer, scrutiny::VariableType::float32, &outval);
-    EXPECT_FALSE(success);
-
-    success = scrutiny_handler.fetch_variable(forbidden_buffer2, scrutiny::VariableType::float32, &outval);
-    EXPECT_FALSE(success);
-
-    success = scrutiny_handler.fetch_variable(readonly_buffer, scrutiny::VariableType::float32, &outval);
-    EXPECT_TRUE(success);
-
-    success = scrutiny_handler.fetch_variable(readonly_buffer2, scrutiny::VariableType::float32, &outval);
-    EXPECT_TRUE(success);
-}
-
 TEST_F(TestVariableFetching, Bitfield)
 {
     unsigned char some_buffer[32];


### PR DESCRIPTION
- Move heavy structure as class members in Datalogger
- Do not check for forbiddenr egion inside the read_memory() func. Chekc s are already done outside.
- Reorganize order of members

Before:
```
========= Stack Usage =========
===============================
   196: MainHadndler::process()
       0: idle
      16: scrutiny::MainHandler::process(unsigned long)
      24: scrutiny::MainHandler::process_request(scrutiny::protocol::Request const*, scrutiny::protocol::Response*)
      68: scrutiny::MainHandler::process_datalog_control(scrutiny::protocol::Request const*, scrutiny::protocol::Response*)
      28: scrutiny::datalogging::DataLogger::configure(scrutiny::Timebase*, unsigned short)
      24: scrutiny::datalogging::RawFormatEncoder::reset()
      24: scrutiny::MainHandler::get_rpv(unsigned short, scrutiny::RuntimePublishedValue*) const
      12: scrutiny::Config::get_rpv_count() const

   264: LoopHandler::process()
       0: loop
       8: scrutiny::VariableFrequencyLoopHandler::process(unsigned long)
      24: scrutiny::LoopHandler::process_common(unsigned long)
       8: scrutiny::datalogging::DataLogger::process()
      60: scrutiny::datalogging::DataLogger::check_trigger()
      40: scrutiny::datalogging::fetch_operand(scrutiny::MainHandler const*, scrutiny::datalogging::Operand const*, scrutiny::ctypes::scrutiny_c_any_type_t*, scrutiny::VariableType::eVariableType*, scrutiny::LoopHandler*)
      40: scrutiny::MainHandler::fetch_variable_bitfield(void const*, scrutiny::VariableTypeType::eVariableTypeType, unsigned int, unsigned int, scrutiny::ctypes::scrutiny_c_any_type_t*, scrutiny::VariableType::eVariableType*) const
      24: scrutiny::MainHandler::fetch_variable(void const*, scrutiny::VariableType::eVariableType, scrutiny::ctypes::scrutiny_c_any_type_t*) const
      16: scrutiny::MainHandler::read_memory(void*, void const*, unsigned long) const
      32: scrutiny::MainHandler::touches_forbidden_region(void const*, unsigned int) const
      12: scrutiny::Config::forbidden_ranges() const
```

```
========= Stack Usage =========
===============================
    196: MainHadndler::process()
       0: idle
      16: scrutiny::MainHandler::process(unsigned long)
      24: scrutiny::MainHandler::process_request(scrutiny::protocol::Request const*, scrutiny::protocol::Response*)
      68: scrutiny::MainHandler::process_datalog_control(scrutiny::protocol::Request const*, scrutiny::protocol::Response*)
      28: scrutiny::datalogging::DataLogger::configure(scrutiny::Timebase*, unsigned short)
      24: scrutiny::datalogging::RawFormatEncoder::reset()
      24: scrutiny::MainHandler::get_rpv(unsigned short, scrutiny::RuntimePublishedValue*) const
      12: scrutiny::Config::get_rpv_count() const

   196: LoopHandler::process()
       0: loop1
       8: scrutiny::VariableFrequencyLoopHandler::process(unsigned long)
      24: scrutiny::LoopHandler::process_common(unsigned long)
       8: scrutiny::datalogging::DataLogger::process()
      36: scrutiny::datalogging::DataLogger::check_trigger()
      40: scrutiny::datalogging::fetch_operand(scrutiny::MainHandler const*, scrutiny::datalogging::Operand const*, scrutiny::ctypes::scrutiny_c_any_type_t*, scrutiny::VariableType::eVariableType*, scrutiny::LoopHandler*)
      40: scrutiny::MainHandler::fetch_variable_bitfield(void const*, scrutiny::VariableTypeType::eVariableTypeType, unsigned int, unsigned int, scrutiny::ctypes::scrutiny_c_any_type_t*, scrutiny::VariableType::eVariableType*) const
      24: scrutiny::MainHandler::fetch_variable(void const*, scrutiny::VariableType::eVariableType, scrutiny::ctypes::scrutiny_c_any_type_t*) const
      16: scrutiny::MainHandler::read_memory(void*, void const*, unsigned long) const
       0: memcpy
```