### PR TITLE
Fix cwrapper cast warning on certain compiler

### DIFF
--- a/cwrapper/scrutiny_cwrapper.cpp
+++ b/cwrapper/scrutiny_cwrapper.cpp
@@ -112,8 +112,8 @@ extern "C"
         get_config(config)->set_published_values(
             reinterpret_cast<scrutiny::RuntimePublishedValue const *>(array), // should match as per static_assert above
             nbr,
-            reinterpret_cast<scrutiny::RpvReadCallback>((void *)rd_cb),   // Expect signature to match
-            reinterpret_cast<scrutiny::RpvWriteCallback>((void *)wr_cb)); // Expect signature to match
+            reinterpret_cast<scrutiny::RpvReadCallback>(reinterpret_cast<void *>(rd_cb)),   // Expect signature to match
+            reinterpret_cast<scrutiny::RpvWriteCallback>(reinterpret_cast<void *>(wr_cb))); // Expect signature to match
     }
 
     void scrutiny_c_config_set_loops(scrutiny_c_config_t *config, scrutiny_c_loop_handler_t **loops, uint_least8_t const loop_count)

--- a/cwrapper/scrutiny_cwrapper.cpp
+++ b/cwrapper/scrutiny_cwrapper.cpp
@@ -112,8 +112,8 @@ extern "C"
         get_config(config)->set_published_values(
             reinterpret_cast<scrutiny::RuntimePublishedValue const *>(array), // should match as per static_assert above
             nbr,
-            reinterpret_cast<scrutiny::RpvReadCallback>(rd_cb),   // Expect signature to match
-            reinterpret_cast<scrutiny::RpvWriteCallback>(wr_cb)); // Expect signature to match
+            reinterpret_cast<scrutiny::RpvReadCallback>((void *)rd_cb),   // Expect signature to match
+            reinterpret_cast<scrutiny::RpvWriteCallback>((void *)wr_cb)); // Expect signature to match
     }
 
     void scrutiny_c_config_set_loops(scrutiny_c_config_t *config, scrutiny_c_loop_handler_t **loops, uint_least8_t const loop_count)


### PR DESCRIPTION
- Fixed function pointer cast warning in cwrapper for certain compilers (witnessed on arm-none-eabi-gcc 13.2)